### PR TITLE
fix: Fixed theme switcher functionality

### DIFF
--- a/src/components/themeSwitcher.tsx
+++ b/src/components/themeSwitcher.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import { DARK_THEME, LIGHT_THEME } from '@/constants';
+import React, { useState } from 'react';
 import { MdOutlineLightMode } from 'react-icons/md';
 import { MdOutlineDarkMode } from 'react-icons/md';
 
@@ -8,19 +9,18 @@ const getPrefersDarkMode = () =>
   window.matchMedia &&
   window.matchMedia('(prefers-color-scheme: dark)').matches;
 
-const getDarkModeSetting = () => {
-  const fromLocalStorage = localStorage.getItem('darkMode');
+const ALTERNATE_THEME = getPrefersDarkMode() ? LIGHT_THEME : DARK_THEME;
+
+const alternateThemeInUse = () => {
+  const fromLocalStorage = localStorage.getItem('saldoAlternateTheme');
   if (fromLocalStorage) {
-    return fromLocalStorage;
+    return JSON.parse(fromLocalStorage) as boolean;
   }
   return getPrefersDarkMode();
 };
 export default function ThemeSwitcher({ className }: { className: string }) {
-  const [darkMode, setDarkMode] = useState(getDarkModeSetting());
-  useEffect(() => {
-    localStorage.setItem('darkMode', JSON.stringify(darkMode));
-    console.log('darkMode', darkMode, localStorage.getItem('darkMode'));
-  }, [darkMode]);
+  const initTheme = alternateThemeInUse();
+  const [alternateTheme, setAlternateTheme] = useState(initTheme);
 
   return (
     <label title="Light/dark mode" className="swap swap-rotate">
@@ -28,12 +28,27 @@ export default function ThemeSwitcher({ className }: { className: string }) {
       <input
         type="checkbox"
         className="theme-controller"
-        value={darkMode ? 'dark' : 'light'}
-        onChange={() => setDarkMode(!darkMode)}
+        checked={initTheme}
+        value={ALTERNATE_THEME}
+        onChange={() => {
+          localStorage.setItem(
+            'saldoAlternateTheme',
+            JSON.stringify(!alternateTheme),
+          );
+          setAlternateTheme(!alternateTheme);
+        }}
       />
-
-      <MdOutlineLightMode className={`${className} swap-on`} />
-      <MdOutlineDarkMode className={`${className} swap-off`} />
+      {ALTERNATE_THEME === LIGHT_THEME ? (
+        <>
+          <MdOutlineLightMode className={`${className} swap-on`} />
+          <MdOutlineDarkMode className={`${className} swap-off`} />
+        </>
+      ) : (
+        <>
+          <MdOutlineLightMode className={`${className} swap-off`} />
+          <MdOutlineDarkMode className={`${className} swap-on`} />
+        </>
+      )}
     </label>
   );
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -10,3 +10,6 @@ export const EXPECTED_MINUTES_LUNCH_BREAK = 30;
 export const NEW_WORKLOG_DEFAULT_FROM = defaultFrom;
 export const NEW_WORKLOG_DEFAULT_TO = defaultTo;
 export const NEW_WORKLOG_DEFAULT_SUBTRACT_LUNCH = true;
+
+export const LIGHT_THEME = 'light';
+export const DARK_THEME = 'dark';


### PR DESCRIPTION
The code changes in this commit update the theme switcher component to use the newly added constants for the light and dark themes. This improves code readability and maintainability by centralizing the theme values. The theme switcher now toggles between the light and dark themes based on the user's preference or the default theme set in local storage.