### PR TITLE
refactor: :art: Use prisma client types only in repositories

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,7 +31,7 @@ export default async function Home({
         date={startOfMonth(
           (searchParams.month as Date_YearAndMonth) || undefined,
         )}
-        beginDate={settings.begin_date}
+        beginDate={settings.beginDate}
         worklogs={worklogs}
       />
     </div>

--- a/src/app/settings/settings.tsx
+++ b/src/app/settings/settings.tsx
@@ -10,16 +10,16 @@ import { startOfDay, timeIsGt } from '@/util/date';
 import { Date_Time, toISODay } from '@/util/dateFormatter';
 import { useTransitionWrapper } from '@/util/useTransitionWrapper';
 import { useContext, useState } from 'react';
-import { Settings as SettingsType } from '@/repository/settingsRepository';
+import { Settings as SettingsType } from '@/types';
 
 export default function Settings({ settings }: { settings: SettingsType }) {
   const [, startTransitionWrapper] = useTransitionWrapper();
   const [data, setData] = useState<{
-    begin_date: Date | null;
-    initial_balance_hours: number | '';
-    initial_balance_mins: number | '';
-    from_default: Date_Time | null;
-    to_default: Date_Time | null;
+    beginDate: Date | null;
+    initialBalanceHours: number | '';
+    initialBalanceMins: number | '';
+    fromDefault: Date_Time | null;
+    toDefault: Date_Time | null;
   }>(settings);
   const { setMsg } = useContext(ToastContext);
 
@@ -32,26 +32,26 @@ export default function Settings({ settings }: { settings: SettingsType }) {
         <div className="flex items-center">
           <IntegerInput
             label="Hours"
-            value={data.initial_balance_hours}
+            value={data.initialBalanceHours}
             className="w-20"
             placeholder="hh"
             onChange={(val) => {
               setData({
                 ...data,
-                initial_balance_hours: val ?? '',
+                initialBalanceHours: val ?? '',
               });
             }}
           />
           <span className="mx-3">:</span>
           <IntegerInput
             label="Minutes"
-            value={data.initial_balance_mins}
+            value={data.initialBalanceMins}
             className="w-20"
             placeholder="mm"
             onChange={(val) => {
               setData({
                 ...data,
-                initial_balance_mins: val ?? '',
+                initialBalanceMins: val ?? '',
               });
             }}
           />
@@ -59,12 +59,12 @@ export default function Settings({ settings }: { settings: SettingsType }) {
         <div>Begin date</div>
         <div>
           <DateInput
-            value={data.begin_date ? toISODay(data.begin_date) : ''}
+            value={data.beginDate ? toISODay(data.beginDate) : ''}
             className="w-full"
             onChange={(value) => {
               setData({
                 ...data,
-                begin_date: value ? startOfDay(value) : null,
+                beginDate: value ? startOfDay(value) : null,
               });
             }}
           />
@@ -74,26 +74,26 @@ export default function Settings({ settings }: { settings: SettingsType }) {
           <TimeInput
             placeholder="From"
             label="From"
-            value={data.from_default ?? ''}
+            value={data.fromDefault ?? ''}
             className="w-full"
             indicatorClassName="w-full mt-4"
             onChange={(value) => {
               setData({
                 ...data,
-                from_default: value ?? null,
+                fromDefault: value ?? null,
               });
             }}
           />
           <TimeInput
             placeholder="To"
             label="To"
-            value={data.to_default ?? ''}
+            value={data.toDefault ?? ''}
             className="w-full"
             indicatorClassName="w-full mt-4"
             onChange={(value) => {
               setData({
                 ...data,
-                to_default: value ?? null,
+                toDefault: value ?? null,
               });
             }}
           />
@@ -104,19 +104,19 @@ export default function Settings({ settings }: { settings: SettingsType }) {
             className="btn btn-secondary mt-3 w-full"
             onClick={() => {
               const action = () => {
-                assertExists(data.begin_date, 'Begin date is required');
-                assertExists(data.from_default, 'From time is required');
-                assertExists(data.to_default, 'To time is required');
+                assertExists(data.beginDate, 'Begin date is required');
+                assertExists(data.fromDefault, 'From time is required');
+                assertExists(data.toDefault, 'To time is required');
 
-                if (timeIsGt(data.from_default, data.to_default)) {
+                if (timeIsGt(data.fromDefault, data.toDefault)) {
                   throw new Error('From time must be before to time');
                 }
-                return onSettingsUpdate(settings.user_id, {
-                  initialBalanceHours: data.initial_balance_hours || 0,
-                  initialBalanceMins: data.initial_balance_mins || 0,
-                  beginDate: data.begin_date,
-                  fromDefault: data.from_default,
-                  toDefault: data.to_default,
+                return onSettingsUpdate(settings.userId, {
+                  initialBalanceHours: data.initialBalanceHours || 0,
+                  initialBalanceMins: data.initialBalanceMins || 0,
+                  beginDate: data.beginDate,
+                  fromDefault: data.fromDefault,
+                  toDefault: data.toDefault,
                 });
               };
               startTransitionWrapper(action)

--- a/src/app/statistics/page.tsx
+++ b/src/app/statistics/page.tsx
@@ -5,11 +5,10 @@ import {
   minutesToSaldoObject,
   worklogMinutes,
 } from '@/services';
-import { SaldoForDay } from '@/types';
+import { AbsenceReason, SaldoForDay, Worklog } from '@/types';
 import { assertIsISODay } from '@/util/assertionFunctions';
 import { Date_ISODay, toDayMonthYear, toISODay } from '@/util/dateFormatter';
 import WorkMinutesPerDayChart from './workMinutesPerDayChart';
-import { Absence, Worklog } from '@prisma/client';
 import { getSettings } from '@/repository/settingsRepository';
 import { endOfDay, isNonWorkingDay } from '@/util/date';
 
@@ -50,12 +49,11 @@ async function getWorklogData(userId: number, beginDate: Date) {
       if (isNonWorkingDay(x.from)) {
         return acc;
       }
-
       return x.absence
         ? acc.set(x.absence, (acc.get(x.absence) ?? 0) + 1)
         : acc;
     },
-    new Map() as Map<Absence, number>,
+    new Map() as Map<AbsenceReason, number>,
   );
 
   return { totalWorkMinutes, workMinutesPerDay, absenceMap };
@@ -70,7 +68,7 @@ export default async function Statistics() {
   if (!settings) {
     return null;
   }
-  const beginDate = settings.begin_date;
+  const beginDate = settings.beginDate;
 
   const { workMinutesPerDay, absenceMap, totalWorkMinutes } =
     await getWorklogData(user.id, beginDate);

--- a/src/app/worklog-entry/existingWorklogs.tsx
+++ b/src/app/worklog-entry/existingWorklogs.tsx
@@ -1,6 +1,6 @@
-import { Worklog } from '@prisma/client';
 import WorklogItem from '@/components/worklogItem/worklogItem';
 import { calculateWorklogsSum } from '@/services';
+import { Worklog } from '@/types';
 
 export default function ExistingWorklogs({
   worklogs,

--- a/src/app/worklog-entry/page.tsx
+++ b/src/app/worklog-entry/page.tsx
@@ -31,8 +31,8 @@ export default async function WorklogEntryPage({
       key={searchParams.day}
       day={searchParams.day}
       defaults={{
-        fromDefault: settings.from_default,
-        toDefault: settings.to_default,
+        fromDefault: settings.fromDefault,
+        toDefault: settings.toDefault,
       }}
       worklogs={worklogs}
       onSubmit={onWorklogSubmit.bind(null, user.id)}

--- a/src/app/worklog-entry/worklogEntry.tsx
+++ b/src/app/worklog-entry/worklogEntry.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { WorklogFormData, WorklogFormDataEntry } from '@/types';
+import { Worklog, WorklogFormData, WorklogFormDataEntry } from '@/types';
 import { add, subtract, toDate } from '@/util/date';
 import {
   Date_ISODay,
@@ -9,7 +9,6 @@ import {
 } from '@/util/dateFormatter';
 import { useContext, useRef, useState } from 'react';
 import ExistingWorklogs from './existingWorklogs';
-import { Worklog } from '@prisma/client';
 import WorklogInputs from '@/components/worklogInputs';
 import { useRouter } from 'next/navigation';
 import { MdArrowBack, MdArrowForward } from 'react-icons/md';

--- a/src/app/worklog-items/worklogItems.tsx
+++ b/src/app/worklog-items/worklogItems.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { Settings, Worklog } from '@prisma/client';
 import WorklogItem from '@/components/worklogItem/worklogItem';
 import { useState } from 'react';
 import {
@@ -15,6 +14,7 @@ import {
   assertIsISODay,
   assertIsYearAndMonth,
 } from '@/util/assertionFunctions';
+import { Settings, Worklog } from '@/types';
 
 function groupWorklogsByDay(worklogs: Worklog[]) {
   return worklogs.reduce((acc: Record<string, Worklog[] | undefined>, x) => {
@@ -138,7 +138,7 @@ export default function WorklogItems({
                   return worklogsOfDayToElements(
                     day,
                     groupedWorklogsByMonth[k]?.[day] ?? [],
-                    settings.begin_date,
+                    settings.beginDate,
                     onWorklogDelete,
                     onWorklogEdit,
                   );

--- a/src/auth/authenticatedContent.tsx
+++ b/src/auth/authenticatedContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Settings, User } from '@prisma/client';
+import { Settings, User } from '@/types';
 import { signIn, useSession } from 'next-auth/react';
 import { MdLockOutline } from 'react-icons/md';
 

--- a/src/components/miniCalendar/__tests__/index.test.tsx
+++ b/src/components/miniCalendar/__tests__/index.test.tsx
@@ -2,8 +2,8 @@ import { describe, expect, test, jest } from '@jest/globals';
 import { render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MiniCalendar from '../index';
-import { Worklog } from '@prisma/client';
 import { useRouter } from 'next/navigation';
+import { Worklog } from '@/types';
 
 // Mock useRouter:
 jest.mock('next/navigation');

--- a/src/components/miniCalendar/index.tsx
+++ b/src/components/miniCalendar/index.tsx
@@ -3,7 +3,6 @@ import { useRef } from 'react';
 import { MdArrowBack, MdArrowForward, MdToday } from 'react-icons/md';
 import { add, startOfMonth, subtract } from '@/util/date';
 import { toISODay, toMonthAndYear, toYearAndMonth } from '@/util/dateFormatter';
-import { Worklog } from '@prisma/client';
 import useSwipeEvents from 'beautiful-react-hooks/useSwipeEvents';
 import { useRouter } from 'next/navigation';
 import WeekItem from './weekItem';
@@ -13,6 +12,7 @@ import {
   daysForCalendarBuilder,
 } from './util';
 import DayItem from './dayItem';
+import { Worklog } from '@/types';
 
 export default function MiniCalendar({
   date,

--- a/src/components/miniCalendar/util.tsx
+++ b/src/components/miniCalendar/util.tsx
@@ -1,5 +1,5 @@
 import { calculateWorklogsSum } from '@/services';
-import { AbsenceReason, SaldoForDay } from '@/types';
+import { AbsenceReason, SaldoForDay, Worklog } from '@/types';
 import { assertIsAbsenceReason } from '@/util/assertionFunctions';
 import {
   add,
@@ -9,7 +9,6 @@ import {
   subtract,
 } from '@/util/date';
 import { toISODay, toWeekday } from '@/util/dateFormatter';
-import { Worklog } from '@prisma/client';
 
 export const CALENDAR_ITEM_CLASS =
   'w-10 sm:w-12 h-12 sm:h-14 sm:text-lg flex justify-center items-center rounded-full';

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -8,8 +8,7 @@ import NavbarItems from './navBarItems';
 import { Session } from 'next-auth';
 import QuickAdd from './quickAdd';
 import SaldoBadge from './saldoBadge';
-import { User, Worklog } from '@prisma/client';
-import { Settings } from '@/repository/settingsRepository';
+import { Settings, User, Worklog } from '@/types';
 
 const ThemeSwitcher = dynamic(() => import('./themeSwitcher'), { ssr: false });
 
@@ -57,8 +56,8 @@ export default function Navbar({
                 key="quickAdd"
                 userId={user.id}
                 defaults={{
-                  fromDefault: settings.from_default,
-                  toDefault: settings.to_default,
+                  fromDefault: settings.fromDefault,
+                  toDefault: settings.toDefault,
                 }}
               />,
             ]

--- a/src/components/quickAddModal.tsx
+++ b/src/components/quickAddModal.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { useContext, useState } from 'react';
-import { Worklog } from '@prisma/client';
 import { toDate } from '@/util/date';
 import WorklogInputs from './worklogInputs';
 import { Date_Time, toISODay } from '@/util/dateFormatter';
@@ -9,7 +8,7 @@ import { NEW_WORKLOG_DEFAULT_SUBTRACT_LUNCH } from '@/constants';
 import { assertIsISODay, assertIsTime } from '@/util/assertionFunctions';
 import Modal from './modal';
 import DateInput from './form/dateInput';
-import { WorklogFormDataEntry } from '@/types';
+import { Worklog, WorklogFormDataEntry } from '@/types';
 import { useTransitionWrapper } from '@/util/useTransitionWrapper';
 import { ToastContext } from './toastContext';
 

--- a/src/components/saldoBadge.tsx
+++ b/src/components/saldoBadge.tsx
@@ -1,5 +1,5 @@
 import { calculateCurrentSaldo } from '@/services';
-import { Settings, Worklog } from '@prisma/client';
+import { Settings, Worklog } from '@/types';
 
 export default function SaldoBadge({
   settings,

--- a/src/components/worklogItem/worklogEditModal.tsx
+++ b/src/components/worklogItem/worklogEditModal.tsx
@@ -1,11 +1,10 @@
 'use client';
 import { useContext, useState } from 'react';
 import WorklogInputs from '../worklogInputs';
-import { Worklog } from '@prisma/client';
 import { toISODay, toTime } from '@/util/dateFormatter';
 import { onWorklogEdit } from '@/actions';
 import { toDate } from '@/util/date';
-import { WorklogFormDataEntry } from '@/types';
+import { Worklog, WorklogFormDataEntry } from '@/types';
 import { assertIsISODay, assertIsTime } from '@/util/assertionFunctions';
 import Modal from '../modal';
 import { useTransitionWrapper } from '@/util/useTransitionWrapper';
@@ -27,7 +26,7 @@ export default function WorklogEditModal({
     from: toTime(worklog.from),
     to: toTime(worklog.to),
     comment: worklog.comment ?? '',
-    subtractLunchBreak: worklog.subtract_lunch_break,
+    subtractLunchBreak: worklog.subtractLunchBreak,
   });
 
   const editWorklog = () => {

--- a/src/components/worklogItem/worklogItem.tsx
+++ b/src/components/worklogItem/worklogItem.tsx
@@ -1,11 +1,11 @@
 'use client';
-import { Worklog } from '@prisma/client';
 import { MdDelete, MdModeEdit } from 'react-icons/md';
 import WorklogTitle from '@/components/worklogItem/worklogTitle';
 import WorklogDeleteConfirm from './worklogDeleteConfirm';
 import { useEffect, useState } from 'react';
 import WorklogEditModal from './worklogEditModal';
 import { showModal } from '../modal';
+import { Worklog } from '@/types';
 
 export default function WorklogItem({
   worklog,

--- a/src/components/worklogItem/worklogTitle.tsx
+++ b/src/components/worklogItem/worklogTitle.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { toTime } from '@/util/dateFormatter';
-import { Worklog } from '@prisma/client';
 import AbsenceIcon from '@/components/worklogItem/absenceIcon';
 import { MdRestaurant } from 'react-icons/md';
 import { absenceReasonToString } from '@/services';
 import { assertIsAbsenceReason } from '@/util/assertionFunctions';
+import { Worklog } from '@/types';
 
 export default function WorklogTitle({ worklog }: { worklog: Worklog }) {
   if (worklog.absence) {
@@ -20,7 +20,7 @@ export default function WorklogTitle({ worklog }: { worklog: Worklog }) {
       </h2>
       {worklog.absence ? (
         <AbsenceIcon absence={worklog.absence} className="w-6 h-6" />
-      ) : worklog.subtract_lunch_break ? (
+      ) : worklog.subtractLunchBreak ? (
         <MdRestaurant className="w-6 h-6" />
       ) : null}
     </div>

--- a/src/repository/settingsRepository.ts
+++ b/src/repository/settingsRepository.ts
@@ -1,15 +1,23 @@
-import { SettingsData } from '@/types';
+import { Settings, SettingsData } from '@/types';
 import { prisma } from './prisma';
 import * as Sentry from '@sentry/nextjs';
-import { Settings as S } from '@prisma/client';
-import { Date_Time } from '@/util/dateFormatter';
+import { Settings as PrismaSettings } from '@prisma/client';
 import { assertIsTime } from '@/util/assertionFunctions';
 
-export interface Settings extends S {
-  from_default: Date_Time;
-  to_default: Date_Time;
-}
-export async function getSettings(userId: number) {
+const toSettings = (settings: PrismaSettings): Settings => {
+  assertIsTime(settings.from_default);
+  assertIsTime(settings.to_default);
+  return {
+    id: settings.id,
+    userId: settings.user_id,
+    beginDate: settings.begin_date,
+    initialBalanceHours: settings.initial_balance_hours,
+    initialBalanceMins: settings.initial_balance_mins,
+    fromDefault: settings.from_default,
+    toDefault: settings.to_default,
+  };
+};
+export async function getSettings(userId: number): Promise<Settings | null> {
   return await Sentry.startSpan(
     { name: 'getSettings', op: 'db.sql.prisma' },
     async () => {
@@ -21,9 +29,7 @@ export async function getSettings(userId: number) {
       if (!s) {
         return null;
       }
-      assertIsTime(s.from_default);
-      assertIsTime(s.to_default);
-      return s as Settings;
+      return toSettings(s);
     },
   );
 }
@@ -36,7 +42,7 @@ export async function insertSettings(
     fromDefault,
     toDefault,
   }: SettingsData,
-) {
+): Promise<Settings> {
   return await Sentry.startSpan(
     { name: 'insertSettings', op: 'db.sql.prisma' },
     async () => {
@@ -54,9 +60,7 @@ export async function insertSettings(
         },
         update: {},
       });
-      assertIsTime(s.from_default);
-      assertIsTime(s.to_default);
-      return s as Settings;
+      return toSettings(s);
     },
   );
 }
@@ -69,7 +73,7 @@ export async function upsertSettings(
     fromDefault,
     toDefault,
   }: SettingsData,
-) {
+): Promise<Settings> {
   return await Sentry.startSpan(
     { name: 'upsertSettings', op: 'db.sql.prisma' },
     async () => {
@@ -93,9 +97,7 @@ export async function upsertSettings(
           to_default: toDefault,
         },
       });
-      assertIsTime(s.from_default);
-      assertIsTime(s.to_default);
-      return s as Settings;
+      return toSettings(s);
     },
   );
 }

--- a/src/repository/userRepository.ts
+++ b/src/repository/userRepository.ts
@@ -1,8 +1,15 @@
-import { AuthUser } from '@/types';
+import { AuthUser, User } from '@/types';
+import { User as PrismaUser } from '@prisma/client';
 import { prisma } from './prisma';
 import * as Sentry from '@sentry/nextjs';
 
-export async function upsertUser({ email, name }: AuthUser) {
+const toUser = (user: PrismaUser): User => ({
+  id: user.id,
+  email: user.email,
+  name: user.name,
+});
+
+export async function upsertUser({ email, name }: AuthUser): Promise<User> {
   return await Sentry.startSpan(
     { name: 'upsertUser', op: 'db.sql.prisma' },
     async () => {
@@ -14,19 +21,19 @@ export async function upsertUser({ email, name }: AuthUser) {
         },
         update: { name },
       });
-      return user;
+      return toUser(user);
     },
   );
 }
 
-export async function getUser(email: string) {
+export async function getUser(email: string): Promise<User | null> {
   return await Sentry.startSpan(
     { name: 'getUser', op: 'db.sql.prisma' },
     async () => {
       const user = await prisma.user.findUnique({
         where: { email },
       });
-      return user;
+      return user ? toUser(user) : null;
     },
   );
 }

--- a/src/repository/worklogRepository.ts
+++ b/src/repository/worklogRepository.ts
@@ -1,7 +1,24 @@
-import { Worklog } from '@prisma/client';
 import { prisma } from './prisma';
-import { WorklogFormData } from '@/types';
+import { Worklog as PrismaWorklog } from '@prisma/client';
+import { Worklog, WorklogFormData } from '@/types';
+import { assertIsAbsenceReason } from '@/util/assertionFunctions';
 import * as Sentry from '@sentry/nextjs';
+
+const toAbsenceReason = (absence: string | null) => {
+  if (!absence) {
+    return null;
+  }
+  assertIsAbsenceReason(absence);
+  return absence;
+};
+const toWorklog = (worklog: PrismaWorklog): Worklog => ({
+  id: worklog.id,
+  from: worklog.from,
+  to: worklog.to,
+  comment: worklog.comment,
+  subtractLunchBreak: worklog.subtract_lunch_break,
+  absence: toAbsenceReason(worklog.absence),
+});
 
 export async function getWorklogs(
   userId: number,
@@ -26,7 +43,7 @@ export async function getWorklogs(
         records: worklogs.length,
       });
 
-      return worklogs;
+      return worklogs.map(toWorklog);
     },
   );
 }
@@ -34,7 +51,7 @@ export async function getWorklogs(
 export async function insertWorklog(
   userId: number,
   { from, to, comment, subtractLunchBreak, absence }: WorklogFormData,
-) {
+): Promise<Worklog> {
   return await Sentry.startSpan(
     { name: 'insertWorklog', op: 'db.sql.prisma' },
     async () => {
@@ -48,7 +65,7 @@ export async function insertWorklog(
           absence,
         },
       });
-      return worklog;
+      return toWorklog(worklog);
     },
   );
 }
@@ -56,7 +73,7 @@ export async function insertWorklog(
 export async function updateWorklog(
   worklogId: number,
   { from, to, comment, subtractLunchBreak }: WorklogFormData,
-) {
+): Promise<Worklog> {
   return await Sentry.startSpan(
     { name: 'updatetWorklog', op: 'db.sql.prisma' },
     async () => {
@@ -69,12 +86,12 @@ export async function updateWorklog(
           subtract_lunch_break: subtractLunchBreak,
         },
       });
-      return worklog;
+      return toWorklog(worklog);
     },
   );
 }
 
-export async function deleteWorklog(worklogId: number) {
+export async function deleteWorklog(worklogId: number): Promise<void> {
   return await Sentry.startSpan(
     { name: 'deleteWorklog', op: 'db.sql.prisma' },
     async () => {

--- a/src/services/__tests__/index.test.tsx
+++ b/src/services/__tests__/index.test.tsx
@@ -5,8 +5,7 @@ import {
   sortWorklogs,
   absenceReasonToString,
 } from '../index';
-import { Settings, Worklog } from '@prisma/client';
-import { AbsenceReason } from '@/types';
+import { AbsenceReason, Settings, Worklog } from '@/types';
 
 describe('worklog calculator', () => {
   describe('calculateCurrentSaldo', () => {
@@ -15,16 +14,16 @@ describe('worklog calculator', () => {
       jest.setSystemTime(new Date('2023-10-22T10:00:00').getTime());
 
       const settings = {
-        begin_date: new Date('2023-10-14'),
-        initial_balance_hours: 2,
-        initial_balance_mins: 30,
+        beginDate: new Date('2023-10-14'),
+        initialBalanceHours: 2,
+        initialBalanceMins: 30,
       } as Settings;
       const worklogs = [
         {
           // friday before begin date, is ignored
           from: new Date('2023-10-13T08:00:00'),
           to: new Date('2023-10-13T16:00:00'),
-          subtract_lunch_break: true,
+          subtractLunchBreak: true,
         },
         {
           // sat flex hours, is ignored
@@ -41,7 +40,7 @@ describe('worklog calculator', () => {
           // mon 8-16:30 without break (+1 hour)
           from: new Date('2023-10-16T08:00:00'),
           to: new Date('2023-10-16T16:30:00'),
-          subtract_lunch_break: false,
+          subtractLunchBreak: false,
         },
         {
           // tue 8-15:30 without break (+/- 0 hour)
@@ -52,7 +51,7 @@ describe('worklog calculator', () => {
           // wed 7-16:15 with lunch break (+1 hour 15 minutes)
           from: new Date('2023-10-18T07:00:00'),
           to: new Date('2023-10-18T16:15:00'),
-          subtract_lunch_break: true,
+          subtractLunchBreak: true,
         },
         {
           // thu flex day (-7.5 hour)
@@ -76,7 +75,7 @@ describe('worklog calculator', () => {
           // mon in future is ignored
           from: new Date('2023-10-23T08:00:00'),
           to: new Date('2023-10-23T16:30:00'),
-          subtract_lunch_break: false,
+          subtractLunchBreak: false,
         },
       ] as unknown as Worklog[];
       const saldo = calculateCurrentSaldo(settings, worklogs);
@@ -105,7 +104,7 @@ describe('worklog calculator', () => {
         {
           from: new Date('2023-02-03T12:00:00'),
           to: new Date('2023-02-03T13:30:00'),
-          subtract_lunch_break: true,
+          subtractLunchBreak: true,
         },
       ] as unknown as Worklog[];
       const sum = calculateWorklogsSum(worklogs);

--- a/src/services/index.tsx
+++ b/src/services/index.tsx
@@ -2,7 +2,7 @@ import {
   EXPECTED_HOURS_PER_DAY,
   EXPECTED_MINUTES_LUNCH_BREAK,
 } from '@/constants';
-import { AbsenceReason, SaldoForDay } from '@/types';
+import { AbsenceReason, SaldoForDay, Settings, Worklog } from '@/types';
 import {
   add,
   diffInMinutes,
@@ -10,7 +10,6 @@ import {
   isNonWorkingDay,
   startOfDay,
 } from '@/util/date';
-import { Absence, Settings, Worklog } from '@prisma/client';
 
 function expectedMinutesUntilToday(beginDate: Date) {
   const today = startOfDay();
@@ -55,13 +54,13 @@ export function minutesToSaldoObject(saldoInMinutes: number): SaldoForDay {
 export function worklogMinutes(worklogItem: Worklog) {
   return (
     diffInMinutes(worklogItem.to, worklogItem.from) -
-    (worklogItem.subtract_lunch_break ? EXPECTED_MINUTES_LUNCH_BREAK : 0)
+    (worklogItem.subtractLunchBreak ? EXPECTED_MINUTES_LUNCH_BREAK : 0)
   );
 }
 export function calculateCurrentSaldo(settings: Settings, worklogs: Worklog[]) {
   const sum = sortWorklogs(worklogs).reduce(
     (acc, worklogItem) => {
-      if (worklogItem.from.getTime() < settings.begin_date.getTime()) {
+      if (worklogItem.from.getTime() < settings.beginDate.getTime()) {
         return acc;
       }
       if (worklogItem.to.getTime() > endOfDay().getTime()) {
@@ -77,9 +76,9 @@ export function calculateCurrentSaldo(settings: Settings, worklogs: Worklog[]) {
       }
       return acc + worklogMinutes(worklogItem);
     },
-    settings.initial_balance_hours * 60 + settings.initial_balance_mins,
+    settings.initialBalanceHours * 60 + settings.initialBalanceMins,
   );
-  const saldoInMinutes = sum - expectedMinutesUntilToday(settings.begin_date);
+  const saldoInMinutes = sum - expectedMinutesUntilToday(settings.beginDate);
   return minutesToSaldoObject(saldoInMinutes);
 }
 
@@ -93,7 +92,7 @@ export function calculateWorklogsSum(worklogs: Worklog[]) {
 export function sortWorklogs(worklogs: Worklog[]) {
   return [...worklogs].sort((a, b) => b.from.getTime() - a.from.getTime());
 }
-export function absenceReasonToString(reason: Absence | AbsenceReason) {
+export function absenceReasonToString(reason: AbsenceReason) {
   return (reason.charAt(0).toUpperCase() + reason.slice(1)).replaceAll(
     '_',
     ' ',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,3 +46,25 @@ export interface SaldoForDay {
   toString: () => string;
   toBadge: (className?: string) => JSX.Element;
 }
+export interface Worklog {
+  id: number;
+  from: Date;
+  to: Date;
+  subtractLunchBreak: boolean;
+  absence: AbsenceReason | null;
+  comment: string | null;
+}
+export interface Settings {
+  id: number;
+  userId: number;
+  beginDate: Date;
+  initialBalanceHours: number;
+  initialBalanceMins: number;
+  fromDefault: Date_Time;
+  toDefault: Date_Time;
+}
+export interface User {
+  id: number;
+  email: string;
+  name: string | null;
+}


### PR DESCRIPTION
Introduced own interfaces for Worklog, Settings, and User. Replaced usage of prisma client types with new ones in such manner that prisma types are used only in repository files.
This prevents db structure to "flood" out into entire app and makes our life easier in the future when db changes affect directly only into repository modules.