### PR TITLE
perf: speed up first-page load in production

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -33,8 +33,9 @@ import {
 } from '@/schemas/resetPasswordSchema';
 
 export async function onAfterSignin(user: AuthUser) {
-  const u = await upsertUser(user.name ?? '');
+  const u = await upsertUser(user.email, user.name ?? '');
   const settings = await insertSettings({
+    userId: u.id,
     beginDate: startOfDay(),
     initialBalanceHours: 0,
     initialBalanceMins: 0,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import { Inter } from 'next/font/google';
 import { AuthProvider } from '@/auth/authProvider';
 import Navbar from '@/components/navbar';
 import { getSession } from '@/auth/authSession';
-import { onAfterSignin } from '@/actions';
+import { getSettings } from '@/repository/settingsRepository';
 import { getWorklogs } from '@/repository/worklogRepository';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -21,14 +21,9 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   const session = await getSession();
-  const data = session?.user?.email
-    ? await onAfterSignin({
-        email: session.user.email,
-        name: session.user.name ?? '',
-      })
-    : null;
-  const settings = data?.[1] ?? null;
-  const worklogs = session ? await getWorklogs() : [];
+  const [settings, worklogs] = session
+    ? await Promise.all([getSettings(), getWorklogs()])
+    : [null, []];
 
   return (
     <html lang="en">

--- a/src/auth/authSession.ts
+++ b/src/auth/authSession.ts
@@ -6,7 +6,7 @@ import { NextAuthOptions, getServerSession } from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
 import GitHubProvider from 'next-auth/providers/github';
 import CredentialsProvider from 'next-auth/providers/credentials';
-import { onCredentialsSignin } from '@/actions';
+import { onAfterSignin, onCredentialsSignin } from '@/actions';
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -46,6 +46,15 @@ export const authOptions: NextAuthOptions = {
     signIn: '/signin',
     signOut: '/auth/signout',
     error: '/auth/error',
+  },
+  events: {
+    signIn: async ({ user }) => {
+      if (!user.email) return;
+      await onAfterSignin({
+        email: user.email,
+        name: user.name ?? '',
+      });
+    },
   },
 };
 

--- a/src/repository/prisma.ts
+++ b/src/repository/prisma.ts
@@ -3,10 +3,16 @@ import { Pool } from 'pg';
 import { PrismaPg } from '@prisma/adapter-pg';
 
 const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClient | undefined;
+  prisma?: PrismaClient;
+  pgPool?: Pool;
 };
 
-const pool = new Pool({ connectionString: process.env.POSTGRES_PRISMA_URL });
+const pool =
+  globalForPrisma.pgPool ??
+  new Pool({
+    connectionString: process.env.POSTGRES_PRISMA_URL,
+    max: 1,
+  });
 const adapter = new PrismaPg(pool);
 
 export const prisma =
@@ -16,6 +22,5 @@ export const prisma =
     log: [/*'query', 'info', */ 'warn', 'error'],
   });
 
-if (process.env.NODE_ENV !== 'production') {
-  globalForPrisma.prisma = prisma;
-}
+globalForPrisma.pgPool = pool;
+globalForPrisma.prisma = prisma;

--- a/src/repository/settingsRepository.ts
+++ b/src/repository/settingsRepository.ts
@@ -41,26 +41,22 @@ export async function getSettings(): Promise<Settings | null> {
   );
 }
 export async function insertSettings({
+  userId,
   beginDate,
   initialBalanceHours,
   initialBalanceMins,
   fromDefault,
   toDefault,
-}: SettingsData): Promise<Settings> {
-  const user = await getUserFromSession();
-  if (!user) {
-    throw new Error('User not found in session.');
-  }
-
+}: SettingsData & { userId: number }): Promise<Settings> {
   return await Sentry.startSpan(
     { name: 'insertSettings', op: 'db.sql.prisma' },
     async () => {
       const s = await prisma.settings.upsert({
         where: {
-          user_id: user.id,
+          user_id: userId,
         },
         create: {
-          user_id: user.id,
+          user_id: userId,
           begin_date: beginDate,
           initial_balance_hours: initialBalanceHours,
           initial_balance_mins: initialBalanceMins,

--- a/src/repository/userRepository.ts
+++ b/src/repository/userRepository.ts
@@ -5,7 +5,6 @@ import { User as PrismaUser } from '@/generated/prisma/client';
 import { prisma } from './prisma';
 import * as Sentry from '@sentry/nextjs';
 import bcrypt from 'bcrypt';
-import { getSession } from '@/auth/authSession';
 import { add } from '@/util/date';
 import { createHash } from 'node:crypto';
 
@@ -15,18 +14,14 @@ const toUser = (user: PrismaUser): User => ({
   name: user.name,
 });
 
-export async function upsertUser(name: string): Promise<User> {
+export async function upsertUser(email: string, name: string): Promise<User> {
   return await Sentry.startSpan(
     { name: 'upsertUser', op: 'db.sql.prisma' },
     async () => {
-      const sessionUser = (await getSession())?.user;
-      if (!sessionUser?.email) {
-        throw new Error('User not found in session.');
-      }
       const prismaUser = await prisma.user.upsert({
-        where: { email: sessionUser.email },
+        where: { email },
         create: {
-          email: sessionUser.email,
+          email,
           name,
         },
         update: { name },


### PR DESCRIPTION
Cache PrismaClient and pg.Pool on globalThis in all environments (the NODE_ENV !== 'production' guard was a fossil from the long-lived next start era and re-instantiated both on every Vercel cold start). Cap the pg pool at max: 1 since pgbouncer multiplexes upstream.

Move the user/settings upsert out of RootLayout (which ran it on every authenticated navigation) into NextAuth's events.signIn so provisioning happens once per actual sign-in. upsertUser/insertSettings now take their identifying args directly instead of reading them from the session.

Parallelize getSettings and getWorklogs in the layout via Promise.all.