### PR TITLE
docs(openspec): initialize OpenSpec with baseline capability specs

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,155 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,160 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,172 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,107 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/commands/opsx/sync.md
+++ b/.claude/commands/opsx/sync.md
@@ -1,0 +1,143 @@
+---
+name: "OPSX: Sync"
+description: Sync delta specs from a change to main specs
+category: Workflow
+tags: [workflow, specs, experimental]
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace spec sync is not supported in this slice and STOP. Do not fall back to repo-local paths or edit linked repos.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace spec sync is not supported in this slice and STOP. Do not fall back to repo-local paths or edit linked repos.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ next-env.d.ts
 .vscode
 
 src/generated/prisma
+
+# Playwright MCP artifacts
+/.playwright-mcp/
+
+# Claude Code local settings (per-machine, not shared)
+.claude/settings.local.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,9 @@
 .prettierignore
 .husky
 .gitignore
+.claude
+.remember
+openspec
 prisma/migrations
 *Dockerfile
 docker-compose*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Saldo is a work-hours tracking app. Its core domain concept is the **saldo** — the running balance between hours actually worked and hours expected (`EXPECTED_HOURS_PER_DAY = 7.5`). The balance is computed from a user's `beginDate` forward, skipping non-working days (weekends + public holidays via `date-holidays`), with a configurable initial balance. See `src/services/index.tsx` for the calculation logic.
+
+## Stack
+
+Next.js 16 (App Router) · React 19 · TypeScript (strict) · Prisma 7 + PostgreSQL (via `pg` adapter) · NextAuth 4 · Tailwind 4 + daisyUI · Zod + react-hook-form · Chart.js · dayjs · Sentry.
+
+## Commands
+
+```bash
+npm run dev          # next dev (port 3000)
+npm run build        # next build (outputs to build/ unless on Vercel)
+npm test             # jest in WATCH mode — does not exit
+npm run test:ci      # jest --ci --coverage — use this for a single run
+npm run lint         # eslint (max-warnings=0) + prettier --check
+npm run lint:fix     # eslint --fix + prettier --write
+```
+
+- **Run a single test:** `npx jest src/services/__tests__/someFile.test.ts` (add `-t "name"` to filter by test name). `npm test` defaults to watch mode and will not terminate.
+- Husky pre-commit runs `lint-staged`; commit-msg enforces Conventional Commits (commitlint). Keep commits conventional or they will be rejected.
+
+## Local setup (Docker Compose)
+
+```bash
+docker compose up -d db   # Postgres on localhost:3006
+./run-migrations.sh       # prisma migrate deploy against localhost:3006
+docker compose up         # app on localhost:3000
+```
+
+`POSTGRES_PRISMA_URL` is the connection string used everywhere. `NEXTAUTH_URL`/`NEXTAUTH_SECRET` and OAuth creds (`GOOGLE_*`, `GITHUB_*`) are required outside local dev. See `docs/getting-started.md`.
+
+## Architecture — layered, server-first
+
+Data flows `page/component → action → repository → Prisma`, with `services` holding pure business logic. Respect these boundaries:
+
+- **`src/app/`** — App Router pages (all `async` server components by default) and the NextAuth route handler. Route groups: `(calendar)` (home), `(login)` (signin/signup/forgot/reset). Pages call repository functions directly to read data.
+- **`src/actions/index.ts`** — the single `'use server'` module. All mutations (worklog CRUD, settings, signup, password reset) go through here. Actions validate input with Zod schemas, then delegate to repositories. This is the only place client components are allowed to trigger writes.
+- **`src/repository/`** — `server-only` data access. Every function calls `getUserFromSession()` first and **enforces per-user ownership** (e.g. `updateWorklog`/`deleteWorklog` throw on `user_id` mismatch). DB calls are wrapped in `Sentry.startSpan`. Mapper functions (e.g. `toWorklog`) translate Prisma's `snake_case` rows into the `camelCase` domain types in `src/types`.
+- **`src/services/index.tsx`** — pure, side-effect-free business logic (saldo calculation, worklog summing/sorting, minutes↔badge formatting). No DB or session access here.
+- **`src/auth/`** — NextAuth config (`authSession.ts`). JWT session strategy; Credentials + Google + GitHub providers. On first sign-in, `onAfterSignin` upserts the user and seeds default `Settings`. The user's numeric DB id is stashed in the JWT (`token.userId`) and surfaced as `session.user.id`. Use `getUserFromSession()` as the auth gate in server code.
+
+### Key conventions
+
+- **Prisma client is generated to `src/generated/prisma`** (not `node_modules`). Import from `@/generated/prisma/client`. Run `prisma generate` after schema changes (also runs on `postinstall`).
+- **Branded date types.** `src/util/dateFormatter.ts` defines opaque string types (`Date_ISODay`, `Date_Time`, `Date_YearAndMonth`, …) and `src/util/assertionFunctions.ts` provides `assertIs*` guards to construct/validate them. Prefer these over raw strings when passing formatted dates around — they catch format mismatches at the type level.
+- **All date math is UTC.** `src/util/date.ts` sets `dayjs.tz.setDefault('UTC')`. Use the helpers there (`add`, `startOfDay`, `isNonWorkingDay`, etc.) rather than calling dayjs directly.
+- **Domain types** (`Worklog`, `Settings`, `User`, `AbsenceReason`, form-data shapes) live in `src/types/index.ts`. The Prisma models are mapped into these at the repository boundary — don't leak Prisma types past it.
+- **Path alias:** `@/*` → `src/*` (configured in both tsconfig and jest).
+- Tests live in `__tests__/` dirs next to the code (jsdom environment, Testing Library). `__mocks__/next/navigation.ts` mocks router for component tests.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -3,11 +3,47 @@ schema: spec-driven
 # Project context (optional)
 # This is shown to AI when creating artifacts.
 # Add your tech stack, conventions, style guides, domain knowledge, etc.
-# Example:
-#   context: |
-#     Tech stack: TypeScript, React, Node.js
-#     We use conventional commits
-#     Domain: e-commerce platform
+context: |
+  Saldo is a work-hours tracking app. Core domain concept: the **saldo** — the
+  running balance between hours actually worked and hours expected
+  (EXPECTED_HOURS_PER_DAY = 7.5). Computed from a user's beginDate forward,
+  skipping non-working days (weekends + public holidays via date-holidays),
+  with a configurable initial balance. Calculation logic lives in
+  src/services/index.tsx.
+
+  Stack: Next.js 16 (App Router) · React 19 · TypeScript (strict) · Prisma 7 +
+  PostgreSQL (pg adapter) · NextAuth 4 · Tailwind 4 + daisyUI · Zod +
+  react-hook-form · Chart.js · dayjs · Sentry.
+
+  Architecture — layered, server-first. Data flows
+  page/component → action → repository → Prisma, with services holding pure
+  business logic. Respect these boundaries:
+  - src/app/ — App Router pages (async server components by default) + NextAuth
+    route handler. Pages call repository functions directly to read data.
+  - src/actions/index.ts — the single 'use server' module. All mutations go
+    here; validate input with Zod, then delegate to repositories. Only place
+    client components may trigger writes.
+  - src/repository/ — server-only data access. Every function calls
+    getUserFromSession() first and enforces per-user ownership. DB calls wrapped
+    in Sentry.startSpan. Mappers translate Prisma snake_case rows into camelCase
+    domain types.
+  - src/services/index.tsx — pure, side-effect-free business logic. No DB or
+    session access.
+  - src/auth/ — NextAuth config (JWT strategy; Credentials + Google + GitHub).
+    getUserFromSession() is the auth gate in server code.
+
+  Key conventions:
+  - Prisma client generated to src/generated/prisma (not node_modules). Import
+    from @/generated/prisma/client. Run prisma generate after schema changes.
+  - Branded date types in src/util/dateFormatter.ts + assertIs* guards in
+    src/util/assertionFunctions.ts. Prefer these over raw strings.
+  - All date math is UTC (src/util/date.ts sets dayjs default to UTC). Use its
+    helpers, not dayjs directly.
+  - Domain types live in src/types/index.ts. Don't leak Prisma types past the
+    repository boundary.
+  - Path alias: @/* → src/*. Tests live in __tests__/ dirs next to the code.
+  - Conventional Commits enforced (commitlint). Husky pre-commit runs
+    lint-staged. Single test run: npm run test:ci. Lint: npm run lint.
 
 # Per-artifact rules (optional)
 # Add custom rules for specific artifacts.

--- a/openspec/specs/absence/spec.md
+++ b/openspec/specs/absence/spec.md
@@ -1,0 +1,98 @@
+# absence Specification
+
+## Purpose
+
+An **absence** records a day a user did not work normally — a holiday, a flex
+day, sick leave, or other. Absences are how non-worked days enter the
+[saldo](../saldo/spec.md) calculation and the statistics. This capability covers
+the set of absence reasons, how absences are entered across a date range, and how
+they are presented.
+
+Storage-wise an absence is not a separate model: it is a [worklog](../worklog/spec.md)
+with its `absence` field set. This spec covers the absence-specific behavior; the
+underlying record lifecycle (create/edit/delete, ownership) lives in the worklog
+spec.
+
+This spec was reverse-engineered from `src/app/absence/absence.tsx`,
+`src/services/index.tsx` (`absenceReasonToString`), `src/components/worklogItem/absenceIcon.tsx`,
+the `AbsenceReason` type, and the Prisma `Absence` enum. It documents current
+behavior, not a desired future state.
+
+## Requirements
+
+### Requirement: Fixed set of absence reasons
+
+The system SHALL support exactly these absence reasons: `holiday`, `flex_hours`,
+`sick_leave`, and `other`. These values SHALL be the only ones offered in the
+entry UI and the only ones the database accepts.
+
+#### Scenario: Reason selection
+
+- **WHEN** a user enters an absence
+- **THEN** they choose from holiday, flex hours, sick leave, or other
+
+### Requirement: Multi-day absence over a date range
+
+The system SHALL let a user create an absence spanning an inclusive date range by
+choosing a from-date, a to-date, a reason, and a comment, producing one absence
+record per day in the range. Each record SHALL use the configured default times
+and mark the lunch break as subtracted.
+
+#### Scenario: Three-day absence
+
+- **GIVEN** a from-date and a to-date three days apart
+- **WHEN** the absence is submitted
+- **THEN** three absence records are created, one per day, all with the chosen reason and comment
+
+#### Scenario: Range normalization
+
+- **WHEN** the chosen from-date is after the to-date
+- **THEN** the UI keeps the range coherent so the from-date is not after the to-date
+
+### Requirement: Human-readable reason labels
+
+The system SHALL render reason codes as human-friendly labels by capitalizing the
+first letter and replacing underscores with spaces (e.g. `sick_leave` →
+"Sick leave").
+
+#### Scenario: Label formatting
+
+- **WHEN** a reason is displayed
+- **THEN** `flex_hours` is shown as "Flex hours" and `sick_leave` as "Sick leave"
+
+### Requirement: Reason iconography
+
+The system SHALL display a distinct icon per absence reason in worklog listings.
+
+#### Scenario: Icon per reason
+
+- **WHEN** an absence appears in a worklog list
+- **THEN** an icon corresponding to its reason is shown
+
+## Open Questions
+
+These are behaviors observed in the code that are ambiguous, inconsistent, or
+potentially defective. They are NOT to be treated as intended requirements until
+resolved.
+
+- **Reason drift between code and tests.** The canonical reasons are
+  `holiday`, `flex_hours`, `sick_leave`, `other` — enforced by both the
+  `AbsenceReason` type and the Prisma `Absence` enum. The saldo service tests
+  instead use `vacation` and `unpaid_leave` (cast through `as unknown` so they
+  never hit the type system or the database). The tests are stale relative to the
+  real reason set; align them, or change the reason set if `vacation`/`unpaid_leave`
+  are actually wanted. (Cross-referenced from the saldo spec.)
+- **Multi-day creation is non-transactional.** Each day is a separate create
+  with no surrounding transaction (the code carries a `// TODO: Handle all in one
+  call`). A failure partway leaves some days persisted and others not.
+- **Absence reason cannot be edited.** Editing a worklog does not touch its
+  `absence` field, so an absence's reason cannot be changed or cleared after
+  creation. (Cross-referenced from the worklog spec.)
+- **Always full-day, fixed times.** Absences are written with the default times
+  and always count as a full expected day in the saldo. Partial-day absences are
+  not supported through the UI, and the saldo would ignore custom times even if
+  one were created.
+- **No overlap detection.** Nothing prevents creating an absence on a day that
+  already has a worklog (or another absence). Both records would then be counted
+  in the saldo and statistics. Decide whether overlaps should be prevented or
+  merged.

--- a/openspec/specs/auth/spec.md
+++ b/openspec/specs/auth/spec.md
@@ -1,0 +1,157 @@
+# auth Specification
+
+## Purpose
+
+Authentication and account lifecycle: signing up, signing in (email/password and
+OAuth), resolving the current user from the session, and resetting a forgotten
+password. Every other capability depends on this one — server-side data access is
+gated by `getUserFromSession()`.
+
+This spec was reverse-engineered from `src/auth/authSession.ts`,
+`src/repository/userRepository.ts`, `src/actions/index.ts`, the `src/schemas/`
+Zod schemas, and the Prisma `User`/`PasswordResetData` models. It documents
+current behavior, not a desired future state. Items that look like defects or
+gaps are listed under "Open Questions" rather than written as blessed
+requirements.
+
+## Requirements
+
+### Requirement: Email/password sign-in
+
+The system SHALL authenticate a user by email and password via a NextAuth
+Credentials provider, returning the user on a bcrypt password match and failing
+sign-in otherwise.
+
+#### Scenario: Correct credentials
+
+- **GIVEN** a user with a stored bcrypt password hash
+- **WHEN** they submit the matching password
+- **THEN** sign-in succeeds and a session is established
+
+#### Scenario: Wrong password or unknown email
+
+- **WHEN** the password does not match, or no user exists for the email, or the user has no stored password
+- **THEN** sign-in fails and returns no user
+
+### Requirement: OAuth sign-in
+
+The system SHALL support signing in with Google and GitHub providers.
+
+#### Scenario: First OAuth sign-in provisions the account
+
+- **GIVEN** a user signing in with Google or GitHub for the first time
+- **WHEN** authentication succeeds
+- **THEN** an account is provisioned for their email with no stored password
+
+### Requirement: JWT session with user id
+
+The system SHALL use a JWT session strategy and SHALL make the user's numeric
+database id available as `session.user.id`. On sign-in the id is resolved and
+stored on the token; on later requests it is backfilled from the email if absent.
+
+#### Scenario: Id surfaced on the session
+
+- **GIVEN** an authenticated request
+- **WHEN** the session is read
+- **THEN** `session.user.id` holds the user's numeric database id
+
+### Requirement: Server-side auth gate
+
+The system SHALL provide `getUserFromSession()` returning the current user only
+when the session has both an email and a numeric id, and null otherwise. Server
+code uses this as the authorization gate.
+
+#### Scenario: Incomplete session
+
+- **WHEN** the session lacks an email or a numeric id
+- **THEN** `getUserFromSession()` returns null and callers treat the request as unauthenticated
+
+### Requirement: First sign-in provisions user and seeds settings
+
+On sign-in the system SHALL upsert the user by email (creating them or updating
+their name) and SHALL seed a default `Settings` row if one does not already
+exist. Seeding SHALL be idempotent — an existing settings row is left unchanged.
+
+#### Scenario: Returning user
+
+- **GIVEN** a user who already has settings
+- **WHEN** they sign in again
+- **THEN** their user record is upserted and their existing settings are not overwritten
+
+### Requirement: Sign-up with validated credentials
+
+The system SHALL register a new email/password user only after validating input:
+a valid email, a non-empty name, a password of 8–20 characters, and a matching
+confirmation. The password SHALL be stored as a bcrypt hash. Sign-up SHALL fail
+if a user with that email already exists.
+
+#### Scenario: Valid sign-up
+
+- **GIVEN** valid, matching sign-up data for a new email
+- **WHEN** sign-up is submitted
+- **THEN** a user is created with a bcrypt-hashed password
+
+#### Scenario: Invalid input
+
+- **WHEN** the email is malformed, the name is empty, the password is out of the 8–20 range, or confirmation does not match
+- **THEN** sign-up returns a field-level error status and no user is created
+
+#### Scenario: Duplicate email
+
+- **GIVEN** an email already registered
+- **WHEN** sign-up is submitted for it
+- **THEN** the operation fails
+
+### Requirement: Forgot-password does not reveal account existence
+
+The system SHALL validate the submitted email and, when a matching user exists,
+generate a single-use reset token, store only its SHA-256 hash with a one-hour
+expiry, and email the raw token to the user. When no user matches, the system
+SHALL return the same success result without sending mail.
+
+#### Scenario: Known email
+
+- **GIVEN** a registered email
+- **WHEN** a password reset is requested
+- **THEN** a hashed, one-hour token is stored and a reset email is sent
+
+#### Scenario: Unknown email
+
+- **GIVEN** an email with no account
+- **WHEN** a password reset is requested
+- **THEN** the response is an identical success and no email is sent
+
+### Requirement: Reset password with a valid token
+
+The system SHALL reset a password only when given a non-expired reset token and a
+valid new password (8–20 characters, matching confirmation). On success it SHALL
+store the new bcrypt hash and delete the used reset token. An invalid or expired
+token SHALL fail.
+
+#### Scenario: Valid token
+
+- **GIVEN** a non-expired reset token and a valid matching new password
+- **WHEN** the reset is submitted
+- **THEN** the password is updated and the token is consumed
+
+#### Scenario: Expired or unknown token
+
+- **WHEN** the token is expired or does not match any stored hash
+- **THEN** the reset fails and no password is changed
+
+## Open Questions
+
+These are behaviors observed in the code that are ambiguous or potentially
+worth revisiting. They are NOT to be treated as intended requirements until
+resolved.
+
+- **20-character password ceiling.** Both sign-up and reset cap passwords at 20
+  characters. This is well below bcrypt's 72-byte limit and blocks passphrase
+  managers. Deliberate product choice or an accidental tight bound?
+- **Internal inconsistency in credential check.** `getUserByEmailAndPassword`
+  returns null for an unknown user but *throws* on a wrong password; the action
+  catches the throw and normalizes both to null. The externally observable
+  behavior is safe (no enumeration), but the internal contract is inconsistent.
+- **Sign-up race.** `signupUser` checks existence then creates; concurrent
+  requests rely on the DB unique constraint to reject the loser, which would
+  surface as an unhandled error rather than the friendly "already exists" path.

--- a/openspec/specs/saldo/spec.md
+++ b/openspec/specs/saldo/spec.md
@@ -1,0 +1,206 @@
+# saldo Specification
+
+## Purpose
+
+The **saldo** is the running balance between hours a user has actually worked and
+the hours they were expected to work. It is the core domain concept of the
+application. This capability covers how that balance is computed from a user's
+worklogs and settings, how absences affect it, and how the resulting value is
+formatted for display.
+
+This spec was reverse-engineered from the existing implementation in
+`src/services/index.tsx` and its tests in `src/services/__tests__/index.test.tsx`.
+It documents current behavior, not a desired future state. Items that look like
+defects or ambiguities are listed under "Open Questions" rather than written as
+blessed requirements.
+
+Pure calculation only — no database or session access. Inputs are a `Settings`
+object and a list of `Worklog` objects; output is a formatted `SaldoForDay`.
+
+## Requirements
+
+### Requirement: Running balance from begin date
+
+The system SHALL compute the saldo as the sum of counted worked minutes minus
+expected minutes, seeded by the user's configured initial balance, measured from
+the user's `beginDate` up to and including the current day.
+
+#### Scenario: Worked example
+
+- **GIVEN** a user with `beginDate` 2023-10-14 and an initial balance of 2h 30min
+- **AND** the current date is 2023-10-22
+- **AND** the worklogs and absences described by the other requirements below
+- **WHEN** the saldo is calculated
+- **THEN** the result is `-0h 45min`
+
+### Requirement: Initial balance seeds the sum
+
+The system SHALL start the worked-minutes total from the user's configured
+initial balance (`initialBalanceHours * 60 + initialBalanceMins`) before adding
+any worklog contributions.
+
+#### Scenario: Non-zero initial balance
+
+- **GIVEN** settings with `initialBalanceHours = 2` and `initialBalanceMins = 30`
+- **WHEN** the saldo is calculated
+- **THEN** 150 minutes are added to the worked total before worklogs are counted
+
+### Requirement: Expected minutes accrue only on working days
+
+The system SHALL count `EXPECTED_HOURS_PER_DAY` (7.5h = 450 minutes) of expected
+time for each working day from `beginDate` through the current day inclusive, and
+SHALL skip non-working days (weekends and public holidays, as determined by
+`isNonWorkingDay`).
+
+#### Scenario: Weekends and holidays do not raise the expectation
+
+- **GIVEN** a date range that includes Saturdays, Sundays, or public holidays
+- **WHEN** expected minutes are accumulated
+- **THEN** those days contribute 0 expected minutes
+- **AND** only working days contribute 450 minutes each
+
+### Requirement: Worked minutes count on any calendar day
+
+The system SHALL count the actual worked minutes of a regular (non-absence)
+worklog regardless of whether the day is a working day, including weekends and
+public holidays.
+
+#### Scenario: Work logged on a Sunday counts
+
+- **GIVEN** a regular worklog on a Sunday from 10:00 to 12:00
+- **WHEN** the saldo is calculated
+- **THEN** 120 worked minutes are added even though Sunday accrues no expected time
+
+### Requirement: Worked minutes net of lunch break
+
+The system SHALL compute a regular worklog's worked minutes as the difference
+between its `to` and `from` times, minus `EXPECTED_MINUTES_LUNCH_BREAK`
+(30 minutes) when `subtractLunchBreak` is set, and minus nothing otherwise.
+
+#### Scenario: Lunch break subtracted
+
+- **GIVEN** a worklog from 07:00 to 16:15 with `subtractLunchBreak = true`
+- **WHEN** its worked minutes are computed
+- **THEN** the result is 525 minutes (555 minus a 30-minute lunch)
+
+#### Scenario: Lunch break not subtracted
+
+- **GIVEN** a worklog from 08:00 to 16:30 with `subtractLunchBreak = false`
+- **WHEN** its worked minutes are computed
+- **THEN** the result is 510 minutes
+
+### Requirement: Worklogs before the begin date are excluded
+
+The system SHALL ignore any worklog whose `from` time is earlier than the user's
+`beginDate`.
+
+#### Scenario: Entry the day before begin date
+
+- **GIVEN** `beginDate` 2023-10-14 and a worklog on 2023-10-13
+- **WHEN** the saldo is calculated
+- **THEN** that worklog contributes nothing
+
+### Requirement: Future worklogs are excluded
+
+The system SHALL ignore any worklog whose `to` time is later than the end of the
+current day.
+
+#### Scenario: Entry dated tomorrow
+
+- **GIVEN** the current date is 2023-10-22 and a worklog dated 2023-10-23
+- **WHEN** the saldo is calculated
+- **THEN** that worklog contributes nothing
+
+### Requirement: Flex-hours absence draws down the balance
+
+The system SHALL treat a worklog with absence reason `flex_hours` as contributing
+zero worked minutes, while the day still accrues expected time if it is a working
+day. The net effect is to reduce the saldo by a full expected day.
+
+#### Scenario: Flex day on a working day
+
+- **GIVEN** a `flex_hours` absence on a working Thursday
+- **WHEN** the saldo is calculated
+- **THEN** 0 worked minutes are added
+- **AND** 450 expected minutes are still accrued for that day (net -450)
+
+### Requirement: Non-flex absence on a working day is balance-neutral
+
+The system SHALL treat a worklog whose absence reason is anything other than
+`flex_hours`, falling on a working day, as contributing exactly
+`EXPECTED_HOURS_PER_DAY` worked minutes (450), regardless of the worklog's stored
+`from`/`to` times. Because the same day also accrues 450 expected minutes, such a
+day is balance-neutral.
+
+#### Scenario: Vacation on a working Friday
+
+- **GIVEN** a non-flex absence on a working Friday with stored times 08:00–16:00
+- **WHEN** the saldo is calculated
+- **THEN** exactly 450 worked minutes are added (the stored times are not used)
+- **AND** 450 expected minutes are accrued (net 0)
+
+### Requirement: Any absence on a non-working day is ignored
+
+The system SHALL treat any absence (flex or non-flex) falling on a non-working
+day as contributing zero worked minutes; such a day also accrues no expected
+time, so it has no effect on the saldo.
+
+#### Scenario: Vacation on a Saturday
+
+- **GIVEN** a non-flex absence on a Saturday
+- **WHEN** the saldo is calculated
+- **THEN** it contributes 0 worked minutes and 0 expected minutes
+
+### Requirement: Saldo formatted as hours, minutes, string, and badge
+
+The system SHALL format the saldo total minutes into a `SaldoForDay` object
+exposing `hours`, `minutes`, a `toString()`, and a `toBadge()` renderer. A
+non-negative saldo SHALL use floored hours/minutes and a success badge; a
+negative saldo SHALL use ceiled hours/minutes and an error badge.
+
+#### Scenario: Negative saldo formatting
+
+- **GIVEN** a saldo total of -45 minutes
+- **WHEN** it is formatted
+- **THEN** `toString()` returns `-0h 45min`
+- **AND** `toBadge()` renders an error-styled badge
+
+#### Scenario: Positive saldo formatting
+
+- **GIVEN** a positive saldo total
+- **WHEN** it is formatted
+- **THEN** hours and minutes are floored
+- **AND** `toBadge()` renders a success-styled badge
+
+### Requirement: Worklog sum aggregation ignores absence semantics
+
+The system SHALL provide a separate aggregation that sums the raw worked minutes
+(net of lunch break) of a given list of worklogs, without applying the begin-date
+window, the future-entry exclusion, or any absence special-casing. This is a
+display total, distinct from the saldo balance.
+
+#### Scenario: Sum over a mixed list
+
+- **GIVEN** worklogs of 2h, an absence stored as 2h, and a 1.5h entry with a lunch break
+- **WHEN** the worklog sum is calculated
+- **THEN** the result is `5h 0min` (2 + 2 + 1, treating every entry by its raw times)
+
+## Open Questions
+
+These are behaviors observed in the code that are ambiguous or potentially
+defective. They are documented here deliberately and are NOT to be treated as
+intended requirements until resolved.
+
+- **Absence reason drift.** The `AbsenceReason` enum in `src/types/index.ts`
+  defines `holiday`, `flex_hours`, `sick_leave`, `other`. The saldo tests instead
+  reference `vacation` and `unpaid_leave`, which are not in the enum. The absence
+  entry UI offers only the enum values. Which set is canonical?
+- **Non-flex absence discards stored times.** A vacation/sick/other absence
+  always credits exactly 7.5h regardless of its stored `from`/`to`. The absence
+  UI always writes a fixed full-day range, so this is currently invisible — but
+  the calculation would silently ignore a partial-day absence if one were ever
+  created. Intended, or a latent trap?
+- **Today's partial day.** Expected minutes count the current day in full
+  (450 min) as soon as the day begins, so the saldo reads negative during the
+  working day until enough hours are logged. Is mid-day saldo meant to reflect a
+  full expected day, or pro-rated?

--- a/openspec/specs/settings/spec.md
+++ b/openspec/specs/settings/spec.md
@@ -1,0 +1,91 @@
+# settings Specification
+
+## Purpose
+
+Per-user configuration that parameterizes the [saldo](../saldo/spec.md)
+calculation and worklog entry: the balance **begin date**, the **initial
+balance** (hours and minutes) carried in at that date, and the **default
+from/to times** prefilled when creating a worklog. Each user has exactly one
+settings row.
+
+This spec was reverse-engineered from `src/repository/settingsRepository.ts`,
+`src/app/settings/settings.tsx`, the `onSettingsUpdate` action, and the Prisma
+`Settings` model. It documents current behavior, not a desired future state.
+
+## Requirements
+
+### Requirement: One settings row per user
+
+The system SHALL store exactly one settings row per user, keyed by user id.
+
+#### Scenario: Read own settings
+
+- **GIVEN** an authenticated user with settings
+- **WHEN** settings are read
+- **THEN** that user's single settings row is returned
+
+#### Scenario: No settings yet
+
+- **GIVEN** an authenticated user without a settings row
+- **WHEN** settings are read
+- **THEN** null is returned
+
+### Requirement: Default settings on account creation
+
+The system SHALL seed a new user's settings with `beginDate` set to the current
+day, a zero initial balance, and the default from/to times, and SHALL not
+overwrite settings that already exist.
+
+#### Scenario: Seed on first sign-in
+
+- **GIVEN** a brand-new account
+- **WHEN** it is provisioned
+- **THEN** settings are created with today's begin date, zero balance, and default times
+
+### Requirement: Update settings
+
+The system SHALL let the authenticated user update their begin date, initial
+balance hours and minutes, and default from/to times, creating the row if it
+does not yet exist.
+
+#### Scenario: Save settings
+
+- **GIVEN** an authenticated user
+- **WHEN** they submit new settings values
+- **THEN** their settings row is updated (or created) with those values
+
+### Requirement: Default times must be well-formed and ordered
+
+The system SHALL treat the stored from/to defaults as time-of-day values and
+SHALL require the default "from" time to be earlier than the default "to" time
+when saving.
+
+#### Scenario: From after to is rejected
+
+- **WHEN** the user saves a default "from" time later than the default "to" time
+- **THEN** saving fails with a validation error
+
+#### Scenario: Stored times are validated on read
+
+- **WHEN** settings are read
+- **THEN** the stored from/to values are asserted to be valid time-of-day strings
+
+## Open Questions
+
+These are behaviors observed in the code that are ambiguous or potentially
+defective. They are NOT to be treated as intended requirements until resolved.
+
+- **Validation is client-side only.** The from-before-to check and the
+  required-field checks live in the settings UI; `onSettingsUpdate` performs no
+  Zod validation and would persist whatever it receives. Same gap as the worklog
+  capability — a non-UI caller could store an inverted time range or empty
+  begin date.
+- **Initial balance sign and bounds.** Nothing observed constrains the initial
+  balance to non-negative values or any range. A negative starting balance may
+  be a legitimate "starting in deficit" case, but it is unspecified — decide
+  whether it is allowed.
+- **Seed path bypasses the session gate.** `insertSettings` takes an explicit
+  `userId` and is not session-gated, unlike every other repository function.
+  This is intentional (it runs during sign-in before a session exists), but it
+  is the one exception to the "every repository call resolves the session user"
+  rule and should be documented as such.

--- a/openspec/specs/statistics/spec.md
+++ b/openspec/specs/statistics/spec.md
@@ -1,0 +1,99 @@
+# statistics Specification
+
+## Purpose
+
+Aggregate views over a user's worklogs: total and average hours, the best and
+worst days, absence counts by reason, and a per-day work-minutes chart. All
+figures are scoped to the same window the [saldo](../saldo/spec.md) uses — from
+the user's begin date up to the end of today.
+
+This spec was reverse-engineered from `src/app/statistics/page.tsx` and
+`src/app/statistics/workMinutesPerDayChart.tsx`. It documents current behavior,
+not a desired future state. Items that look like defects are listed under "Open
+Questions" rather than written as blessed requirements.
+
+## Requirements
+
+### Requirement: Statistics require an authenticated user with settings
+
+The system SHALL render statistics only for an authenticated user who has a
+settings row; otherwise it renders nothing.
+
+#### Scenario: No session or no settings
+
+- **WHEN** there is no authenticated user, or the user has no settings
+- **THEN** the statistics view renders nothing
+
+### Requirement: Same window as the saldo
+
+The system SHALL include only worklogs whose `from` is at or after the begin date
+and whose `to` is at or before the end of today, matching the saldo window.
+
+#### Scenario: Out-of-window entries excluded
+
+- **GIVEN** worklogs before the begin date or dated in the future
+- **WHEN** statistics are computed
+- **THEN** those entries are excluded from every figure
+
+### Requirement: Separate work entries from absences
+
+The system SHALL partition in-window worklogs into work entries (no absence
+reason) and absences (with a reason), and SHALL base the hours figures on work
+entries only.
+
+#### Scenario: Absences excluded from hours totals
+
+- **GIVEN** a mix of work entries and absences in the window
+- **WHEN** total and average hours are computed
+- **THEN** only work entries contribute
+
+### Requirement: Hours figures
+
+The system SHALL report total hours logged (sum of work-entry minutes, net of
+lunch breaks), average hours per logged day, and the days with the most and least
+logged hours.
+
+#### Scenario: Totals and extremes
+
+- **GIVEN** work entries across several days
+- **WHEN** statistics are computed
+- **THEN** the total is the sum of all work-entry minutes
+- **AND** the most/least figures identify the highest and lowest single-day totals
+
+### Requirement: Absence counts by reason
+
+The system SHALL count absences per reason, excluding absences that fall on
+non-working days.
+
+#### Scenario: Absence tally
+
+- **GIVEN** absences across the window
+- **WHEN** the absence tally is computed
+- **THEN** each reason shows the count of its working-day occurrences
+
+### Requirement: Per-day work-minutes chart
+
+The system SHALL render a chart of worked minutes per day for the in-window work
+entries.
+
+#### Scenario: Chart renders
+
+- **WHEN** there are in-window work entries
+- **THEN** a per-day work-minutes chart is shown
+
+## Open Questions
+
+These are behaviors observed in the code that are ambiguous or potentially
+defective. They are NOT to be treated as intended requirements until resolved.
+
+- **Division by zero with no work entries.** Average hours per day divides the
+  total by the number of distinct logged days. With no in-window work entries
+  that denominator is zero, producing `NaN` and a "NaNh NaNmin" display. Needs an
+  empty-state.
+- **"Average per day" denominator is logged days, not working days.** The average
+  divides by the count of distinct days that have a work entry, not by the number
+  of working days in the window. So a sparse logger sees a high average. Decide
+  which denominator the label "Avg hours per day" should mean.
+- **Negative/garbage spans flow through.** Totals use raw worklog minutes, so an
+  entry with `to` before `from` (which nothing currently prevents — see the
+  worklog spec) would skew every figure. Depends on resolving worklog validation.

--- a/openspec/specs/worklog/spec.md
+++ b/openspec/specs/worklog/spec.md
@@ -1,0 +1,155 @@
+# worklog Specification
+
+## Purpose
+
+A **worklog** is a single time entry for a user: a `from`/`to` timestamp pair on a
+given day, an optional comment, a lunch-break flag, and an optional absence
+reason. Worklogs are the raw records from which the [saldo](../saldo/spec.md)
+balance is computed. This capability covers reading, creating, editing, and
+deleting worklogs, and the per-user ownership rules that guard them.
+
+This spec was reverse-engineered from `src/repository/worklogRepository.ts`,
+`src/actions/index.ts`, and the entry UI under `src/app/worklog-entry/`. It
+documents current behavior, not a desired future state. Items that look like
+defects or gaps are listed under "Open Questions" rather than written as blessed
+requirements.
+
+Worklog storage is the data model that absences also use — an absence is a
+worklog with its `absence` field set. The absence *workflow* (multi-day creation,
+reason selection) is specified separately under the absence capability; this spec
+covers the underlying worklog records.
+
+## Requirements
+
+### Requirement: Worklogs are scoped to the authenticated user
+
+The system SHALL resolve the current user from the session before any worklog
+read or write, and SHALL throw if no user is present in the session. All reads
+SHALL be filtered to the current user's records.
+
+#### Scenario: No session
+
+- **WHEN** any worklog repository function is called without an authenticated session
+- **THEN** the operation throws and no data is read or written
+
+#### Scenario: Listing returns only own worklogs
+
+- **GIVEN** an authenticated user
+- **WHEN** worklogs are listed
+- **THEN** only worklogs belonging to that user are returned
+
+### Requirement: List worklogs with an optional date range
+
+The system SHALL return the current user's worklogs, optionally bounded by a
+`from` lower bound (inclusive, matched against the worklog `from`) and a `to`
+upper bound (inclusive, matched against the worklog `to`). When a bound is
+omitted, that side is unbounded.
+
+#### Scenario: Range query
+
+- **GIVEN** a `from` and `to` date
+- **WHEN** worklogs are listed
+- **THEN** only worklogs whose `from` is at or after the lower bound and whose `to` is at or before the upper bound are returned
+
+#### Scenario: Unbounded query
+
+- **WHEN** worklogs are listed with no bounds
+- **THEN** all of the user's worklogs are returned
+
+### Requirement: Create a worklog
+
+The system SHALL create a worklog for the current user from a `from` timestamp,
+`to` timestamp, comment, `subtractLunchBreak` flag, and optional absence reason,
+and SHALL return the created record mapped to the domain type.
+
+#### Scenario: Regular entry
+
+- **GIVEN** an authenticated user and valid worklog form data
+- **WHEN** the worklog is created
+- **THEN** a new record is persisted for that user and returned
+
+### Requirement: Edit a worklog only if owned
+
+The system SHALL allow editing a worklog's `from`, `to`, comment, and
+`subtractLunchBreak` fields only when the worklog belongs to the current user,
+and SHALL throw a user-mismatch error otherwise.
+
+#### Scenario: Owner edits
+
+- **GIVEN** a worklog owned by the current user
+- **WHEN** it is edited
+- **THEN** the listed fields are updated and the record is returned
+
+#### Scenario: Non-owner edit rejected
+
+- **GIVEN** a worklog owned by a different user
+- **WHEN** the current user attempts to edit it
+- **THEN** the operation throws a user-mismatch error and nothing is changed
+
+### Requirement: Delete a worklog only if owned
+
+The system SHALL delete a worklog only when it belongs to the current user, and
+SHALL throw a user-mismatch error otherwise.
+
+#### Scenario: Owner deletes
+
+- **GIVEN** a worklog owned by the current user
+- **WHEN** it is deleted
+- **THEN** the record is removed
+
+#### Scenario: Non-owner delete rejected
+
+- **GIVEN** a worklog owned by a different user
+- **WHEN** the current user attempts to delete it
+- **THEN** the operation throws a user-mismatch error and nothing is removed
+
+### Requirement: Map storage rows to the domain type
+
+The system SHALL translate stored worklog rows (snake_case columns) into the
+camelCase `Worklog` domain type, mapping `subtract_lunch_break` to
+`subtractLunchBreak` and validating the stored `absence` string into an
+`AbsenceReason` (or null when empty).
+
+#### Scenario: Unknown absence value
+
+- **GIVEN** a stored worklog whose `absence` value is not a recognized reason
+- **WHEN** it is mapped to the domain type
+- **THEN** the assertion fails rather than silently producing an invalid value
+
+### Requirement: Worklog mutations are exposed through server actions
+
+The system SHALL expose worklog create, edit, and delete to client components
+only through the `'use server'` actions module, which delegates to the repository.
+
+#### Scenario: Client triggers a write
+
+- **WHEN** a client component submits a worklog
+- **THEN** the write flows through a server action into the repository, never directly to the database
+
+## Open Questions
+
+These are behaviors observed in the code that are ambiguous, inconsistent, or
+potentially defective. They are documented deliberately and are NOT to be treated
+as intended requirements until resolved.
+
+- **Edit silently ignores the absence field.** `updateWorklog` updates `from`,
+  `to`, comment, and lunch flag, but not `absence`. A worklog created as an
+  absence cannot have its reason changed or cleared through editing, and the
+  caller gets no error. Intended, or a bug? (See also the saldo spec's
+  absence-reason drift question.)
+- **No server-side validation of worklog mutations.** Unlike the auth flows
+  (signup, password reset), the worklog actions perform no Zod validation. The
+  entry UI only asserts that day/time strings are well-*formatted* on the client;
+  nothing enforces that `to` is after `from`, that a worklog has non-zero
+  duration, or that times are within sane bounds. A malformed or zero/negative
+  span would persist and feed straight into the saldo calculation.
+- **Existence check precedes ownership check.** Edit and delete first fetch the
+  worklog with `findUniqueOrThrow`, then compare ownership. A request for a
+  non-existent id throws a "not found" error, while an existing-but-foreign id
+  throws "user mismatch" — the differing errors could distinguish which ids
+  exist. Low severity, but worth a deliberate decision.
+- **Multi-day absence creation is non-transactional.** The absence workflow
+  issues one create per day with no surrounding transaction (`absence.tsx` even
+  carries a `// TODO: Handle all in one call`). A partial failure leaves some days
+  persisted and others not. This belongs to the absence capability but originates
+  in repeated worklog creates.


### PR DESCRIPTION
Initializes OpenSpec for the repo and captures the current behavior as
reverse-engineered baseline specs.

## What's included
- OpenSpec tooling: skills + /opsx slash commands, openspec/config.yaml
  (project context seeded from CLAUDE.md)
- Six baseline capability specs documenting current behavior:
  auth, settings, worklog, absence, saldo, statistics (41 requirements)
- .gitignore: ignore .playwright-mcp/ and .claude/settings.local.json

## Note
The specs document existing behavior, not new contracts. Each spec lists
"Open Questions" for known gaps/quirks (e.g. missing server-side validation
on worklog/settings mutations, statistics divide-by-zero, absence reason
drift). None of these are fixed here — they're a backlog for follow-up
change proposals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
