### PR TITLE
Cover the login tree and the error paths no layer reached

### DIFF
--- a/__mocks__/next/navigation.ts
+++ b/__mocks__/next/navigation.ts
@@ -11,3 +11,6 @@ const router = {
 };
 
 export const useRouter = jest.fn().mockImplementation(() => router);
+
+// Nav components highlight the current route, so this is settable per test.
+export const usePathname = jest.fn(() => '/');

--- a/__mocks__/next/navigation.ts
+++ b/__mocks__/next/navigation.ts
@@ -1,8 +1,13 @@
 import { jest } from '@jest/globals';
 
 const pushMock = jest.fn();
+const refreshMock = jest.fn();
 const router = {
   push: pushMock,
+  // useTransitionWrapper calls refresh() after every mutation, so a mock without it
+  // makes the wrapper throw — which surfaces as a component's own error branch
+  // firing on the success path, or as an unhandled rejection nothing asserts on.
+  refresh: refreshMock,
 };
 
 export const useRouter = jest.fn().mockImplementation(() => router);

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -29,7 +29,13 @@ const config = {
     '^server-only$': '<rootDir>/__mocks__/empty.ts',
   },
 
-  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/generated/**'],
+  // Declaration files hold no runtime code, so counting their lines only depresses
+  // the figure with statements nothing could ever execute.
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/generated/**',
+    '!src/**/*.d.ts',
+  ],
 
   // The e2e/ suite is Playwright's (its *.spec.ts would otherwise be picked up
   // by Jest's default testMatch and fail on @playwright/test imports).

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -27,6 +27,10 @@ const config = {
     // Server-layer modules (repositories, auth) import it as a build guard; map
     // it to a no-op so those modules can be exercised under jsdom.
     '^server-only$': '<rootDir>/__mocks__/empty.ts',
+    // Chart.js's dayjs date adapter ships ESM only, so Jest cannot parse it. It only
+    // matters for rendering a real time axis; the chart's data and options can be
+    // asserted without it, so it maps to a no-op.
+    '^chartjs-adapter-dayjs-4/.*$': '<rootDir>/__mocks__/empty.ts',
   },
 
   // Declaration files hold no runtime code, so counting their lines only depresses

--- a/src/app/(login)/__tests__/formFieldErrorHandler.test.ts
+++ b/src/app/(login)/__tests__/formFieldErrorHandler.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import type { Path, UseFormSetError } from 'react-hook-form';
+
+import { handleFormFieldErrors } from '../formFieldErrorHandler';
+
+// Server-side validation returns errors keyed by field name, and this is what puts
+// them back on the form. The guard against an unknown key is the interesting half:
+// react-hook-form's setError on a field that does not exist would attach an error
+// nothing renders, so the message would vanish rather than be shown.
+
+type Form = { email: string };
+type Setter = UseFormSetError<Form>;
+
+const knownFields: { [k: string]: Path<Form> } = { email: 'email' };
+
+describe('handleFormFieldErrors', () => {
+  it('puts a server error on the field it names', () => {
+    const setError = jest.fn<Setter>();
+
+    handleFormFieldErrors<Form>(
+      { email: 'Already taken' },
+      setError,
+      knownFields,
+    );
+
+    expect(setError).toHaveBeenCalledWith('email', {
+      type: 'server',
+      message: 'Already taken',
+    });
+  });
+
+  it('ignores an error naming a field the form does not have', () => {
+    const setError = jest.fn<Setter>();
+
+    handleFormFieldErrors<Form>({ mystery: 'nope' }, setError, knownFields);
+
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it('applies every recognised field in one pass', () => {
+    type TwoFields = { email: string; name: string };
+    const setError = jest.fn<UseFormSetError<TwoFields>>();
+
+    handleFormFieldErrors<TwoFields>(
+      { email: 'Already taken', name: 'Required', mystery: 'nope' },
+      setError,
+      { email: 'email', name: 'name' },
+    );
+
+    expect(setError).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/(login)/forgot-password/__tests__/forgotPasswordForm.test.tsx
+++ b/src/app/(login)/forgot-password/__tests__/forgotPasswordForm.test.tsx
@@ -1,0 +1,93 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+// Mock factory is not hoisted here (this file imports `jest` from @jest/globals),
+// hence the dynamic import in beforeAll — the same shape as the sign-up form's test.
+jest.mock('@/actions', () => ({ onForgotPassword: jest.fn() }));
+
+type ForgotResult = { status: string; errors?: { [k: string]: string } };
+type ForgotMock = jest.Mock<(data: unknown) => Promise<ForgotResult>>;
+
+let ForgotPasswordForm: typeof import('../forgotPasswordForm').ForgotPasswordForm;
+let forgot: ForgotMock;
+
+beforeAll(async () => {
+  ForgotPasswordForm = (await import('../forgotPasswordForm'))
+    .ForgotPasswordForm;
+  forgot = (await import('@/actions'))
+    .onForgotPassword as unknown as ForgotMock;
+});
+
+const onSuccess = jest.fn<(msg: ReactNode, description?: ReactNode) => void>();
+const onError = jest.fn<(msg: ReactNode) => void>();
+
+beforeEach(() => {
+  forgot.mockReset();
+  onSuccess.mockReset();
+  onError.mockReset();
+  render(<ForgotPasswordForm onSuccess={onSuccess} onError={onError} />);
+});
+
+const submitWith = async (email: string) => {
+  const user = userEvent.setup();
+  await user.type(screen.getByPlaceholderText('Email'), email);
+  await user.click(screen.getByRole('button', { name: 'Continue' }));
+};
+
+describe('ForgotPasswordForm', () => {
+  it('confirms the request without claiming the address exists', async () => {
+    forgot.mockResolvedValue({ status: 'success' });
+
+    await submitWith('ada@example.com');
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+    const [title, description] = onSuccess.mock.calls[0];
+    render(
+      <>
+        {title}
+        {description}
+      </>,
+    );
+    expect(screen.getByText('Email sent!')).toBeInTheDocument();
+    // The wording has to stay non-committal: the same response is returned whether
+    // or not an account matched, which is the requirement this form serves.
+    expect(screen.getByText(/if the email is valid/i)).toBeInTheDocument();
+  });
+
+  it('shows a rejected field against that field', async () => {
+    forgot.mockResolvedValue({
+      status: 'error',
+      errors: { email: 'Enter a valid email' },
+    });
+
+    await submitWith('ada@example.com');
+
+    expect(await screen.findByText('Enter a valid email')).toBeInTheDocument();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the reason when the action throws', async () => {
+    forgot.mockRejectedValue(new Error('mail transport unavailable'));
+
+    await submitWith('ada@example.com');
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith('mail transport unavailable'),
+    );
+  });
+
+  it('does not reach the action when the email is malformed', async () => {
+    await submitWith('not-an-email');
+
+    await waitFor(() => expect(forgot).not.toHaveBeenCalled());
+  });
+});

--- a/src/app/(login)/forgot-password/__tests__/page.test.tsx
+++ b/src/app/(login)/forgot-password/__tests__/page.test.tsx
@@ -1,0 +1,63 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Same shape as the sign-up page test: the real form driven through a mocked action,
+// so the page's success and error callbacks are exercised as they are actually wired.
+// This one also carries a description alongside the title, which is the branch in
+// Message that the other pages never reach.
+jest.mock('@/actions', () => ({ onForgotPassword: jest.fn() }));
+
+type ForgotMock = jest.Mock<(data: unknown) => Promise<{ status: string }>>;
+
+let ForgotPassword: typeof import('../page').default;
+let forgot: ForgotMock;
+
+beforeAll(async () => {
+  ForgotPassword = (await import('../page')).default;
+  forgot = (await import('@/actions'))
+    .onForgotPassword as unknown as ForgotMock;
+});
+
+beforeEach(() => {
+  forgot.mockReset();
+  render(<ForgotPassword />);
+});
+
+const submitValidly = async () => {
+  const user = userEvent.setup();
+  await user.type(screen.getByPlaceholderText('Email'), 'ada@example.com');
+  await user.click(screen.getByRole('button', { name: 'Continue' }));
+};
+
+describe('ForgotPassword page', () => {
+  it('offers a way to sign up instead', () => {
+    expect(screen.getByRole('link', { name: /sign ?up/i })).toBeInTheDocument();
+  });
+
+  it('shows the confirmation with its explanatory detail', async () => {
+    forgot.mockResolvedValue({ status: 'success' });
+
+    await submitValidly();
+
+    expect(await screen.findByText('Email sent!')).toBeInTheDocument();
+    expect(screen.getByText(/if the email is valid/i)).toBeInTheDocument();
+  });
+
+  it('shows the failure the form reports', async () => {
+    forgot.mockRejectedValue(new Error('mail transport unavailable'));
+
+    await submitValidly();
+
+    expect(
+      await screen.findByText('mail transport unavailable'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/(login)/reset-password/__tests__/page.test.tsx
+++ b/src/app/(login)/reset-password/__tests__/page.test.tsx
@@ -1,0 +1,113 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ResetPassword is an async server component: awaited, then the element rendered.
+//
+// This page is the guard that decides whether a token from a URL is allowed to reach
+// the reset form at all, so all three answers are driven: no token, a token matching
+// no stored hash, and a good one. Page2 is deliberately left real, so the accepted
+// path proves the form is reachable and carries the token rather than proving a stub
+// was called.
+jest.mock('@/repository/userRepository', () => ({
+  getUserByPasswordResetToken: jest.fn(),
+}));
+jest.mock('@/actions', () => ({ onResetPassword: jest.fn() }));
+
+type LookupMock = jest.Mock<(token: string) => Promise<unknown>>;
+type SearchParams = { [key: string]: string | string[] | undefined };
+
+let ResetPassword: (props: {
+  params: { slug: string };
+  searchParams: Promise<SearchParams>;
+}) => Promise<React.ReactElement>;
+let lookup: LookupMock;
+
+beforeAll(async () => {
+  ResetPassword = (await import('../page')).default;
+  lookup = (await import('@/repository/userRepository'))
+    .getUserByPasswordResetToken as unknown as LookupMock;
+});
+
+beforeEach(() => {
+  lookup.mockReset();
+});
+
+const renderPage = async (searchParams: SearchParams) => {
+  const element = await ResetPassword({
+    params: { slug: 'reset-password' },
+    searchParams: Promise.resolve(searchParams),
+  });
+  return render(element);
+};
+
+describe('ResetPassword page', () => {
+  it('refuses a link with no token', async () => {
+    await renderPage({});
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid token');
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('refuses a link whose token parameter repeats', async () => {
+    await renderPage({ token: ['one', 'two'] });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid token');
+    // An array cannot identify a single token, so no lookup is attempted.
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('refuses a token that matches no stored hash', async () => {
+    lookup.mockResolvedValue(null);
+
+    await renderPage({ token: 'expired-or-forged' });
+
+    expect(lookup).toHaveBeenCalledWith('expired-or-forged');
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid token');
+  });
+
+  it('shows the reset form for a token that resolves to a user', async () => {
+    lookup.mockResolvedValue({ id: 1, email: 'ada@example.com' });
+
+    await renderPage({ token: 'good-token' });
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('New password')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Reset password' }),
+    ).toBeInTheDocument();
+  });
+
+  it('reports the outcome once the new password is submitted', async () => {
+    lookup.mockResolvedValue({ id: 1, email: 'ada@example.com' });
+    const reset = (await import('@/actions'))
+      .onResetPassword as unknown as jest.Mock<
+      (data: unknown) => Promise<{ status: string }>
+    >;
+    reset.mockResolvedValue({ status: 'success' });
+
+    await renderPage({ token: 'good-token' });
+
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByPlaceholderText('New password'),
+      'hunter2hunter2',
+    );
+    await user.type(
+      screen.getByPlaceholderText('Confirm new password'),
+      'hunter2hunter2',
+    );
+    await user.click(screen.getByRole('button', { name: 'Reset password' }));
+
+    expect(
+      await screen.findByText('Password reset successfully!'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/(login)/reset-password/__tests__/resetPasswordForm.test.tsx
+++ b/src/app/(login)/reset-password/__tests__/resetPasswordForm.test.tsx
@@ -1,0 +1,112 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+// Mock factory is not hoisted here (this file imports `jest` from @jest/globals),
+// hence the dynamic import in beforeAll.
+jest.mock('@/actions', () => ({ onResetPassword: jest.fn() }));
+
+type ResetResult = { status: string; errors?: { [k: string]: string } };
+type ResetMock = jest.Mock<(data: { token?: string }) => Promise<ResetResult>>;
+
+let ResetPasswordForm: typeof import('../resetPasswordForm').ResetPasswordForm;
+let reset: ResetMock;
+
+beforeAll(async () => {
+  ResetPasswordForm = (await import('../resetPasswordForm')).ResetPasswordForm;
+  reset = (await import('@/actions')).onResetPassword as unknown as ResetMock;
+});
+
+const onSuccess = jest.fn<(msg: ReactNode) => void>();
+const onError = jest.fn<(msg: ReactNode) => void>();
+
+beforeEach(() => {
+  reset.mockReset();
+  onSuccess.mockReset();
+  onError.mockReset();
+  render(
+    <ResetPasswordForm
+      token="token-from-the-emailed-link"
+      onSuccess={onSuccess}
+      onError={onError}
+    />,
+  );
+});
+
+const submitWith = async (password: string, confirmation = password) => {
+  const user = userEvent.setup();
+  await user.type(screen.getByPlaceholderText('New password'), password);
+  await user.type(
+    screen.getByPlaceholderText('Confirm new password'),
+    confirmation,
+  );
+  await user.click(screen.getByRole('button', { name: 'Reset password' }));
+};
+
+describe('ResetPasswordForm', () => {
+  it('sends the token from the link along with the new password', async () => {
+    reset.mockResolvedValue({ status: 'success' });
+
+    await submitWith('hunter2hunter2');
+
+    // Without the token the reset cannot be attributed to anyone, so it carrying
+    // through from the URL is the part worth pinning.
+    await waitFor(() =>
+      expect(reset).toHaveBeenCalledWith(
+        expect.objectContaining({ token: 'token-from-the-emailed-link' }),
+      ),
+    );
+  });
+
+  it('reports success with a way to reach the sign-in page', async () => {
+    reset.mockResolvedValue({ status: 'success' });
+
+    await submitWith('hunter2hunter2');
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+    render(<>{onSuccess.mock.calls[0][0]}</>);
+    expect(
+      screen.getByText('Password reset successfully!'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Login here' })).toHaveAttribute(
+      'href',
+      '/signin',
+    );
+  });
+
+  it('shows a rejected field against that field', async () => {
+    reset.mockResolvedValue({
+      status: 'error',
+      errors: { password: 'Token expired' },
+    });
+
+    await submitWith('hunter2hunter2');
+
+    expect(await screen.findByText('Token expired')).toBeInTheDocument();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the reason when the action throws', async () => {
+    reset.mockRejectedValue(new Error('token lookup failed'));
+
+    await submitWith('hunter2hunter2');
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith('token lookup failed'),
+    );
+  });
+
+  it('does not reach the action when the confirmation does not match', async () => {
+    await submitWith('hunter2hunter2', 'something-else');
+
+    await waitFor(() => expect(reset).not.toHaveBeenCalled());
+  });
+});

--- a/src/app/(login)/signin/__tests__/errorMessage.test.tsx
+++ b/src/app/(login)/signin/__tests__/errorMessage.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import { ErrorMessage } from '../errorMessage';
+
+// NextAuth reports a failed sign-in by putting a code in the query string, and this
+// is the only thing that turns it into something a user can act on. The code arrives
+// as whatever the URL held, so all three shapes have to be handled: absent, a single
+// value, and repeated (which URLSearchParams surfaces as an array).
+
+describe('ErrorMessage', () => {
+  it('renders nothing when the sign-in did not fail', () => {
+    const { container } = render(<ErrorMessage error={undefined} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('says which part to correct when the credentials were rejected', () => {
+    render(<ErrorMessage error="CredentialsSignin" />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Invalid email or password. Please try again.',
+    );
+  });
+
+  it('falls back to a generic message for a code it does not recognise', () => {
+    render(<ErrorMessage error="Configuration" />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'An error occurred. Please try again.',
+    );
+  });
+
+  it('falls back to a generic message when the parameter repeats', () => {
+    render(<ErrorMessage error={['CredentialsSignin', 'Configuration']} />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'An error occurred. Please try again.',
+    );
+  });
+});

--- a/src/app/(login)/signin/__tests__/page.test.tsx
+++ b/src/app/(login)/signin/__tests__/page.test.tsx
@@ -1,0 +1,77 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+// Signin is an async server component: it is awaited and the returned element
+// rendered, as in the statistics page test.
+//
+// The auth module is mocked because its next-auth import would otherwise pull in
+// the ESM-only openid-client, and the two sign-in panels are stubbed because what
+// is under test here is the redirect guard and the error surfaced from the URL.
+jest.mock('@/auth/authSession', () => ({ getSession: jest.fn() }));
+jest.mock('next/navigation', () => ({ redirect: jest.fn() }));
+jest.mock('../oauthSignin', () => ({ OAuthSignin: () => null }));
+jest.mock('../credentialsSignin', () => ({ CredentialsSignin: () => null }));
+
+type SessionMock = jest.Mock<() => Promise<unknown>>;
+type RedirectMock = jest.Mock<(url: string) => void>;
+type SearchParams = { [key: string]: string | string[] | undefined };
+
+let Signin: (props: {
+  searchParams: Promise<SearchParams>;
+}) => Promise<React.ReactElement>;
+let getSession: SessionMock;
+let redirect: RedirectMock;
+
+beforeAll(async () => {
+  Signin = (await import('../page')).default;
+  getSession = (await import('@/auth/authSession'))
+    .getSession as unknown as SessionMock;
+  redirect = (await import('next/navigation'))
+    .redirect as unknown as RedirectMock;
+});
+
+beforeEach(() => {
+  getSession.mockReset();
+  redirect.mockReset();
+});
+
+const renderSignin = async (searchParams: SearchParams = {}) => {
+  const element = await Signin({ searchParams: Promise.resolve(searchParams) });
+  return render(element);
+};
+
+describe('Signin page', () => {
+  it('sends an already signed-in visitor to the app', async () => {
+    getSession.mockResolvedValue({ user: { id: 1 } });
+
+    await renderSignin();
+
+    expect(redirect).toHaveBeenCalledWith('/');
+  });
+
+  it('explains a failed attempt reported in the query string', async () => {
+    getSession.mockResolvedValue(null);
+
+    await renderSignin({ error: 'CredentialsSignin' });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Invalid email or password. Please try again.',
+    );
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('shows no alert on a first visit', async () => {
+    getSession.mockResolvedValue(null);
+
+    await renderSignin();
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(login)/signin/__tests__/signinPanels.test.tsx
+++ b/src/app/(login)/signin/__tests__/signinPanels.test.tsx
@@ -1,0 +1,93 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// The two ways into the app. Each hands off to next-auth's signIn, and which
+// provider id it passes is the whole of its logic — 'google' where the button says
+// GitHub would send people to the wrong account. The credentials form also refuses
+// to call signIn at all until both fields are filled.
+//
+// next-auth/react is mocked because its real entry pulls in the ESM-only
+// openid-client, which Jest cannot load.
+jest.mock('next-auth/react', () => ({ signIn: jest.fn() }));
+
+type SignInMock = jest.Mock<
+  (provider: string, options?: Record<string, unknown>) => Promise<unknown>
+>;
+
+let CredentialsSignin: typeof import('../credentialsSignin').CredentialsSignin;
+let OAuthSignin: typeof import('../oauthSignin').OAuthSignin;
+let signIn: SignInMock;
+
+beforeAll(async () => {
+  CredentialsSignin = (await import('../credentialsSignin')).CredentialsSignin;
+  OAuthSignin = (await import('../oauthSignin')).OAuthSignin;
+  signIn = (await import('next-auth/react')).signIn as unknown as SignInMock;
+});
+
+beforeEach(() => {
+  signIn.mockReset();
+});
+
+describe('OAuthSignin', () => {
+  it.each([
+    ['Google', 'google'],
+    ['GitHub', 'github'],
+  ])('signs in with %s through the matching provider', async (name, id) => {
+    render(<OAuthSignin />);
+
+    await userEvent
+      .setup()
+      // The accessible name also carries the logo's alt text, so this matches on the
+      // label rather than the whole string.
+      .click(
+        screen.getByRole('button', {
+          name: new RegExp(`Sign in with ${name}`),
+        }),
+      );
+
+    expect(signIn).toHaveBeenCalledWith(id);
+  });
+});
+
+describe('CredentialsSignin', () => {
+  beforeEach(() => {
+    render(<CredentialsSignin />);
+  });
+
+  it('offers a way out for someone who forgot their password', () => {
+    expect(
+      screen.getByRole('link', { name: 'Forgot password?' }),
+    ).toHaveAttribute('href', '/forgot-password');
+  });
+
+  it('signs in with what was typed', async () => {
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText('Email'), 'ada@example.com');
+    await user.type(screen.getByPlaceholderText('Password'), 'hunter2');
+
+    await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await waitFor(() =>
+      expect(signIn).toHaveBeenCalledWith('credentials', {
+        email: 'ada@example.com',
+        password: 'hunter2',
+      }),
+    );
+  });
+
+  it('does not attempt a sign-in with an empty form', async () => {
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await waitFor(() => expect(signIn).not.toHaveBeenCalled());
+  });
+});

--- a/src/app/(login)/signup/__tests__/page.test.tsx
+++ b/src/app/(login)/signup/__tests__/page.test.tsx
@@ -1,0 +1,69 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// The page owns the two callbacks the form calls back into, and turning those into
+// a visible success or error message is all it does. Driving the real form through
+// the mocked action is what exercises that wiring, rather than calling the callbacks
+// directly and asserting nothing about how they are hooked up.
+jest.mock('@/actions', () => ({ onAfterSignup: jest.fn() }));
+
+type SignupMock = jest.Mock<(data: unknown) => Promise<{ status: string }>>;
+
+let Signup: typeof import('../page').default;
+let signup: SignupMock;
+
+beforeAll(async () => {
+  Signup = (await import('../page')).default;
+  signup = (await import('@/actions')).onAfterSignup as unknown as SignupMock;
+});
+
+beforeEach(() => {
+  signup.mockReset();
+  render(<Signup />);
+});
+
+const submitValidly = async () => {
+  const user = userEvent.setup();
+  await user.type(screen.getByPlaceholderText('Name'), 'Ada');
+  await user.type(screen.getByPlaceholderText('Email'), 'ada@example.com');
+  await user.type(screen.getByPlaceholderText('Password'), 'hunter2hunter2');
+  await user.type(
+    screen.getByPlaceholderText('Confirm password'),
+    'hunter2hunter2',
+  );
+  await user.click(screen.getByRole('button', { name: 'Create an account' }));
+};
+
+describe('Signup page', () => {
+  it('offers a way back to sign-in before anything is submitted', () => {
+    expect(screen.getByRole('link', { name: /sign ?in/i })).toBeInTheDocument();
+  });
+
+  it('shows the success message the form reports', async () => {
+    signup.mockResolvedValue({ status: 'success' });
+
+    await submitValidly();
+
+    expect(
+      await screen.findByText('User added succesfully!'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the failure the form reports', async () => {
+    signup.mockRejectedValue(new Error('email service unavailable'));
+
+    await submitValidly();
+
+    expect(
+      await screen.findByText('email service unavailable'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/(login)/signup/__tests__/signupForm.test.tsx
+++ b/src/app/(login)/signup/__tests__/signupForm.test.tsx
@@ -1,0 +1,119 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+// The form's only write path is the onAfterSignup server action, so mocking it is
+// what lets each of the four outcomes be driven: accepted, rejected with field
+// errors, thrown, and refused client-side before the action is reached. The mock
+// factory is not hoisted (this file imports `jest` from @jest/globals), hence the
+// dynamic import in beforeAll.
+jest.mock('@/actions', () => ({ onAfterSignup: jest.fn() }));
+
+type SignupResult = { status: string; errors?: { [k: string]: string } };
+type SignupMock = jest.Mock<(data: unknown) => Promise<SignupResult>>;
+
+let SignupForm: typeof import('../signupForm').SignupForm;
+let signup: SignupMock;
+
+beforeAll(async () => {
+  SignupForm = (await import('../signupForm')).SignupForm;
+  signup = (await import('@/actions')).onAfterSignup as unknown as SignupMock;
+});
+
+const onSuccess = jest.fn<(msg: ReactNode) => void>();
+const onError = jest.fn<(msg: ReactNode) => void>();
+
+beforeEach(() => {
+  signup.mockReset();
+  onSuccess.mockReset();
+  onError.mockReset();
+  render(<SignupForm onSuccess={onSuccess} onError={onError} />);
+});
+
+/** Fill every field with values the schema accepts. */
+const fillValidly = async () => {
+  const user = userEvent.setup();
+  await user.type(screen.getByPlaceholderText('Name'), 'Ada');
+  await user.type(screen.getByPlaceholderText('Email'), 'ada@example.com');
+  await user.type(screen.getByPlaceholderText('Password'), 'hunter2hunter2');
+  await user.type(
+    screen.getByPlaceholderText('Confirm password'),
+    'hunter2hunter2',
+  );
+  return user;
+};
+
+const submit = async (user: ReturnType<typeof userEvent.setup>) =>
+  user.click(screen.getByRole('button', { name: 'Create an account' }));
+
+describe('SignupForm', () => {
+  it('reports success with a way to reach the sign-in page', async () => {
+    signup.mockResolvedValue({ status: 'success' });
+    const user = await fillValidly();
+
+    await submit(user);
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+    // Rendering what it passed up is the only way to assert the node's content.
+    render(<>{onSuccess.mock.calls[0][0]}</>);
+    expect(screen.getByText('User added succesfully!')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Login here' })).toHaveAttribute(
+      'href',
+      '/signin',
+    );
+  });
+
+  it('shows a rejected field against that field', async () => {
+    signup.mockResolvedValue({
+      status: 'error',
+      errors: { email: 'Email already in use' },
+    });
+    const user = await fillValidly();
+
+    await submit(user);
+
+    expect(await screen.findByText('Email already in use')).toBeInTheDocument();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the reason when the action throws', async () => {
+    signup.mockRejectedValue(new Error('database is on fire'));
+    const user = await fillValidly();
+
+    await submit(user);
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith('database is on fire'),
+    );
+  });
+
+  it('falls back to a generic message when what was thrown is not an Error', async () => {
+    signup.mockRejectedValue('just a string');
+    const user = await fillValidly();
+
+    await submit(user);
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith('An error occurred.'),
+    );
+  });
+
+  it('does not reach the action when the input is invalid', async () => {
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText('Email'), 'not-an-email');
+
+    await submit(user);
+
+    // The schema rejects it first, so nothing is sent and the user is told why.
+    await waitFor(() => expect(signup).not.toHaveBeenCalled());
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/__tests__/error.test.tsx
+++ b/src/app/__tests__/error.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import GlobalError from '../error';
+
+// The error boundary is what a user sees when a page throws, so it is the one screen
+// that must not itself be broken. Nothing else renders it: no test deliberately
+// throws from a page, and no browser journey can.
+
+describe('GlobalError', () => {
+  it('explains what happened and gives the code to quote', () => {
+    render(
+      <GlobalError
+        error={Object.assign(new Error('settings failed to load'), {
+          digest: 12345,
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByText('Oops, something just went sideways'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('settings failed to load')).toBeInTheDocument();
+    // The digest is the only handle on the server-side log entry.
+    expect(screen.getByText(/12345/)).toBeInTheDocument();
+  });
+});

--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -1,0 +1,162 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+
+import type { Date_Time } from '@/util/dateFormatter';
+import type { Settings } from '@/types';
+
+// The root layout runs on every route, and its one decision governs whether every
+// page in the app issues three database reads or none. Getting it wrong is not a
+// rendering bug: reading for a signed-out visitor would query for a user who is not
+// there on every request, and skipping the reads for a signed-in one would leave the
+// navbar with no saldo and no clock.
+//
+// It is not rendered here. The layout returns <html>/<body>, which cannot be mounted
+// inside jsdom's existing document, so the element tree is inspected directly and the
+// reads are asserted at the repository boundary.
+jest.mock('@/auth/authSession', () => ({ getSession: jest.fn() }));
+jest.mock('@/repository/settingsRepository', () => ({
+  getSettings: jest.fn(),
+}));
+jest.mock('@/repository/worklogRepository', () => ({ getWorklogs: jest.fn() }));
+jest.mock('@/repository/clockRepository', () => ({
+  getActiveSession: jest.fn(),
+}));
+jest.mock('@/auth/authProvider', () => ({
+  AuthProvider: () => null,
+}));
+jest.mock('@/components/navbar', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('next/font/google', () => ({
+  Inter: () => ({ className: 'inter' }),
+}));
+
+type ResolvingMock = jest.Mock<(...args: unknown[]) => Promise<unknown>>;
+
+let RootLayout: (props: {
+  children: React.ReactNode;
+}) => Promise<React.ReactElement>;
+let maxDuration: number;
+let getSession: ResolvingMock;
+let getSettings: ResolvingMock;
+let getWorklogs: ResolvingMock;
+let getActiveSession: ResolvingMock;
+
+beforeAll(async () => {
+  const mod = await import('../layout');
+  RootLayout = mod.default;
+  maxDuration = mod.maxDuration;
+  getSession = (await import('@/auth/authSession'))
+    .getSession as unknown as ResolvingMock;
+  getSettings = (await import('@/repository/settingsRepository'))
+    .getSettings as unknown as ResolvingMock;
+  getWorklogs = (await import('@/repository/worklogRepository'))
+    .getWorklogs as unknown as ResolvingMock;
+  getActiveSession = (await import('@/repository/clockRepository'))
+    .getActiveSession as unknown as ResolvingMock;
+});
+
+const time = (s: string) => s as Date_Time;
+
+const settings: Settings = {
+  id: 1,
+  beginDate: new Date('2026-01-01T00:00:00Z'),
+  initialBalanceHours: 0,
+  initialBalanceMins: 0,
+  fromDefault: time('08:00'),
+  toDefault: time('16:00'),
+  expectedMinutesPerDay: 450,
+};
+
+/** The props the layout hands its navbar, dug out of the returned element tree. */
+type NavbarProps = {
+  settings: Settings | null;
+  session: unknown;
+  worklogs: unknown[];
+  activeSession: unknown;
+};
+
+type Node = { props?: Record<string, unknown> } | null | undefined;
+
+/**
+ * The props the layout hands its navbar.
+ *
+ * Found by walking the element tree for the node carrying navbar props rather than
+ * by a fixed depth, so inserting or removing a wrapper does not silently make this
+ * read the wrong element's props.
+ */
+const navbarProps = async (): Promise<NavbarProps> => {
+  const isNavbar = (node: Node): node is { props: NavbarProps } =>
+    !!node && typeof node === 'object' && 'worklogs' in (node.props ?? {});
+
+  const find = (node: Node): NavbarProps | null => {
+    if (isNavbar(node)) {
+      return node.props;
+    }
+    const children = node?.props?.children as unknown;
+    for (const child of Array.isArray(children) ? children : [children]) {
+      const found = find(child as Node);
+      if (found) {
+        return found;
+      }
+    }
+    return null;
+  };
+
+  const props = find((await RootLayout({ children: null })) as unknown as Node);
+  if (!props) {
+    throw new Error('layout rendered no navbar');
+  }
+  return props;
+};
+
+beforeEach(() => {
+  getSession.mockReset();
+  getSettings.mockReset();
+  getWorklogs.mockReset();
+  getActiveSession.mockReset();
+  getSettings.mockResolvedValue(settings);
+  getWorklogs.mockResolvedValue([]);
+  getActiveSession.mockResolvedValue(null);
+});
+
+describe('RootLayout', () => {
+  it('reads the navbar data for a signed-in visitor', async () => {
+    getSession.mockResolvedValue({ user: { id: 1 } });
+
+    const props = await navbarProps();
+
+    expect(getSettings).toHaveBeenCalled();
+    expect(getWorklogs).toHaveBeenCalled();
+    expect(getActiveSession).toHaveBeenCalled();
+    expect(props.settings).toEqual(settings);
+  });
+
+  it('reads nothing for a signed-out visitor', async () => {
+    getSession.mockResolvedValue(null);
+
+    const props = await navbarProps();
+
+    // Three queries per request for a user who is not there, on every route.
+    expect(getSettings).not.toHaveBeenCalled();
+    expect(getWorklogs).not.toHaveBeenCalled();
+    expect(getActiveSession).not.toHaveBeenCalled();
+    // The navbar still renders, and knows to show nothing.
+    expect(props.settings).toBeNull();
+    expect(props.worklogs).toEqual([]);
+    expect(props.activeSession).toBeNull();
+  });
+
+  it('gives every nested route headroom for a cold database start', () => {
+    // A route-segment declaration read by the platform: if this were dropped, a
+    // first request that woke a sleeping database would be killed at the default.
+    expect(maxDuration).toBe(30);
+  });
+});

--- a/src/app/__tests__/manifest.test.ts
+++ b/src/app/__tests__/manifest.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@jest/globals';
+
+import manifest from '../manifest';
+
+// The webmanifest is what makes the app installable, and nothing else reads it — a
+// typo in start_url or a missing icon would only show up on someone's home screen.
+
+describe('manifest', () => {
+  it('describes an installable app', () => {
+    const { name, start_url, display, icons } = manifest();
+
+    expect(name).toBe('saldo');
+    expect(start_url).toBe('/');
+    expect(display).toBe('standalone');
+    expect(icons).toHaveLength(1);
+  });
+});

--- a/src/app/__tests__/pages.test.tsx
+++ b/src/app/__tests__/pages.test.tsx
@@ -1,0 +1,207 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import type { Date_Time } from '@/util/dateFormatter';
+import type { ExpectedHoursOverride, Settings, Worklog } from '@/types';
+
+// The route entry points: async server components that read, assert what must exist,
+// and hand the result to a client component. Their own logic is the reading and the
+// picking — which override belongs to the requested day, and what happens when a user
+// has no settings row yet. Each returns a thin tree, so the children are stubbed to
+// report the props they were given.
+jest.mock('@/repository/worklogRepository', () => ({ getWorklogs: jest.fn() }));
+jest.mock('@/repository/settingsRepository', () => ({
+  getSettings: jest.fn(),
+}));
+jest.mock('@/repository/expectedHoursOverrideRepository', () => ({
+  getExpectedHoursOverrides: jest.fn(),
+}));
+jest.mock('@/actions', () => ({ onWorklogSubmit: jest.fn() }));
+jest.mock('../worklog-items/worklogItems', () => ({
+  __esModule: true,
+  default: ({ worklogs }: { worklogs: Worklog[] }) => (
+    <div>{`items:${worklogs.map((w) => w.id).join(',')}`}</div>
+  ),
+}));
+jest.mock('../worklog-entry/worklogEntry', () => ({
+  __esModule: true,
+  default: ({
+    day,
+    expectedMinutes,
+    override,
+  }: {
+    day: string;
+    expectedMinutes: number;
+    override: ExpectedHoursOverride | null;
+    // One interpolated string, so the assertion is not defeated by JSX splitting the
+    // value into separate text nodes.
+  }) => (
+    <div>{`entry:${day}:${expectedMinutes}:${override ? override.id : 'no-override'}`}</div>
+  ),
+}));
+jest.mock('../settings/settings', () => ({
+  __esModule: true,
+  default: () => <div>settings-form</div>,
+}));
+jest.mock('../settings/expectedHoursOverrides', () => ({
+  __esModule: true,
+  default: ({ overrides }: { overrides: ExpectedHoursOverride[] }) => (
+    <div>{`overrides:${overrides.length}`}</div>
+  ),
+}));
+
+type ResolvingMock = jest.Mock<(...args: unknown[]) => Promise<unknown>>;
+
+let WorklogItemsPage: () => Promise<React.ReactElement>;
+let WorklogEntryPage: (props: {
+  searchParams: Promise<{ day: string }>;
+}) => Promise<React.ReactElement>;
+let SettingsPage: () => Promise<React.ReactElement>;
+let getWorklogs: ResolvingMock;
+let getSettings: ResolvingMock;
+let getOverrides: ResolvingMock;
+
+beforeAll(async () => {
+  WorklogItemsPage = (await import('../worklog-items/page')).default;
+  WorklogEntryPage = (await import('../worklog-entry/page')).default;
+  SettingsPage = (await import('../settings/page')).default;
+  getWorklogs = (await import('@/repository/worklogRepository'))
+    .getWorklogs as unknown as ResolvingMock;
+  getSettings = (await import('@/repository/settingsRepository'))
+    .getSettings as unknown as ResolvingMock;
+  getOverrides = (await import('@/repository/expectedHoursOverrideRepository'))
+    .getExpectedHoursOverrides as unknown as ResolvingMock;
+});
+
+const time = (s: string) => s as Date_Time;
+
+const settings: Settings = {
+  id: 1,
+  beginDate: new Date('2026-01-01T00:00:00Z'),
+  initialBalanceHours: 0,
+  initialBalanceMins: 0,
+  fromDefault: time('08:00'),
+  toDefault: time('16:00'),
+  expectedMinutesPerDay: 450,
+};
+
+const worklog = (id: number, from: string): Worklog => ({
+  id,
+  from: new Date(from),
+  to: new Date(from),
+  subtractLunchBreak: false,
+  absence: null,
+  comment: null,
+});
+
+beforeEach(() => {
+  getWorklogs.mockReset();
+  getSettings.mockReset();
+  getOverrides.mockReset();
+  getSettings.mockResolvedValue(settings);
+  getWorklogs.mockResolvedValue([]);
+  getOverrides.mockResolvedValue([]);
+});
+
+describe('WorklogItemsPage', () => {
+  it('hands the worklogs down in order', async () => {
+    getWorklogs.mockResolvedValue([
+      worklog(2, '2026-07-02T08:00:00Z'),
+      worklog(1, '2026-07-01T08:00:00Z'),
+    ]);
+
+    render(await WorklogItemsPage());
+
+    // Sorted before rendering, newest first.
+    expect(screen.getByText('items:2,1')).toBeInTheDocument();
+  });
+
+  it('refuses to render for a user with no settings', async () => {
+    getSettings.mockResolvedValue(null);
+
+    await expect(WorklogItemsPage()).rejects.toThrow();
+  });
+});
+
+describe('WorklogEntryPage', () => {
+  const renderDay = async (day: string) =>
+    render(await WorklogEntryPage({ searchParams: Promise.resolve({ day }) }));
+
+  it('passes a working day through with the default expectation', async () => {
+    // A Monday: the default applies.
+    await renderDay('2026-07-27');
+
+    expect(
+      screen.getByText('entry:2026-07-27:450:no-override'),
+    ).toBeInTheDocument();
+  });
+
+  it('expects nothing on a non-working day', async () => {
+    // A Sunday. Carrying the weekday default onto a weekend would make every
+    // Saturday and Sunday look like a 7.5-hour debt.
+    await renderDay('2026-07-26');
+
+    expect(
+      screen.getByText('entry:2026-07-26:0:no-override'),
+    ).toBeInTheDocument();
+  });
+
+  it('picks the override belonging to the day being viewed', async () => {
+    getOverrides.mockResolvedValue([
+      {
+        id: 5,
+        date: new Date('2026-07-27T00:00:00Z'),
+        minutes: 240,
+        label: null,
+      },
+      {
+        id: 6,
+        date: new Date('2026-07-28T00:00:00Z'),
+        minutes: 120,
+        label: null,
+      },
+    ]);
+
+    await renderDay('2026-07-27');
+
+    // The day's own override, at its minutes — not the next day's.
+    expect(screen.getByText('entry:2026-07-27:240:5')).toBeInTheDocument();
+  });
+
+  it('refuses a day that is not a date', async () => {
+    await expect(
+      WorklogEntryPage({ searchParams: Promise.resolve({ day: 'tomorrow' }) }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('SettingsPage', () => {
+  it('shows the form and the special days together', async () => {
+    getOverrides.mockResolvedValue([
+      {
+        id: 1,
+        date: new Date('2026-07-26T00:00:00Z'),
+        minutes: 240,
+        label: null,
+      },
+    ]);
+
+    render(await SettingsPage());
+
+    expect(screen.getByText('settings-form')).toBeInTheDocument();
+    expect(screen.getByText('overrides:1')).toBeInTheDocument();
+  });
+
+  it('refuses to render for a user with no settings', async () => {
+    getSettings.mockResolvedValue(null);
+
+    await expect(SettingsPage()).rejects.toThrow();
+  });
+});

--- a/src/app/settings/__tests__/expectedHoursOverrides.test.tsx
+++ b/src/app/settings/__tests__/expectedHoursOverrides.test.tsx
@@ -1,0 +1,185 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+import type { ExpectedHoursOverride } from '@/types';
+
+// Special days override the expected hours for one date, so the list has to stay
+// correct after every change: a save replaces the entry for that date rather than
+// adding a second one, and a removal takes only its own row. Both are done optimistically
+// in local state, which is where a wrong filter would show up — and where the browser
+// suite cannot see it, because it reloads the page afterwards.
+jest.mock('@/actions', () => ({
+  onExpectedHoursOverrideUpsert: jest.fn(),
+  onExpectedHoursOverrideDelete: jest.fn(),
+}));
+
+type UpsertMock = jest.Mock<(data: unknown) => Promise<ExpectedHoursOverride>>;
+type DeleteMock = jest.Mock<(id: number) => Promise<unknown>>;
+
+let ExpectedHoursOverrides: typeof import('../expectedHoursOverrides').default;
+let ToastContext: typeof import('@/components/toastContext').ToastContext;
+let upsert: UpsertMock;
+let remove: DeleteMock;
+
+beforeAll(async () => {
+  ExpectedHoursOverrides = (await import('../expectedHoursOverrides')).default;
+  ToastContext = (await import('@/components/toastContext')).ToastContext;
+  const actions = await import('@/actions');
+  upsert = actions.onExpectedHoursOverrideUpsert as unknown as UpsertMock;
+  remove = actions.onExpectedHoursOverrideDelete as unknown as DeleteMock;
+});
+
+const setMsg = jest.fn<(msg: unknown) => void>();
+
+const override = (
+  id: number,
+  date: string,
+  minutes: number,
+  label: string | null = null,
+): ExpectedHoursOverride => ({ id, date: new Date(date), minutes, label });
+
+const shownToast = () => {
+  const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
+  return { type: msg.type, ...render(<>{msg.message}</>) };
+};
+
+const renderOverrides = (overrides: ExpectedHoursOverride[] = []) =>
+  render(
+    <ToastContext.Provider value={{ msg: null, setMsg }}>
+      <ExpectedHoursOverrides overrides={overrides} />
+    </ToastContext.Provider>,
+  );
+
+const dateField = () => screen.getByPlaceholderText('Date');
+const saveButton = () =>
+  screen.getByRole('button', { name: 'Add special day' });
+
+beforeEach(() => {
+  upsert.mockReset();
+  remove.mockReset();
+  setMsg.mockReset();
+});
+
+describe('ExpectedHoursOverrides', () => {
+  it('says so when there are none', () => {
+    renderOverrides();
+
+    expect(screen.getByText('No special days yet.')).toBeInTheDocument();
+  });
+
+  it('lists them oldest first, whatever order they arrive in', () => {
+    renderOverrides([
+      override(2, '2026-03-10T00:00:00Z', 240),
+      override(1, '2026-01-06T00:00:00Z', 450, 'Short Friday'),
+    ]);
+
+    const rows = screen.getAllByRole('button', { name: /—/ });
+    expect(rows[0]).toHaveTextContent('6.1.2026');
+    expect(rows[1]).toHaveTextContent('10.3.2026');
+    // The label is shown alongside the figure when there is one.
+    expect(rows[0]).toHaveTextContent('Short Friday');
+  });
+
+  it('cannot save until a date is chosen', () => {
+    renderOverrides();
+
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it('saves a new special day and clears the form', async () => {
+    const saved = override(3, '2026-05-01T00:00:00Z', 270, 'May Day');
+    upsert.mockResolvedValue(saved);
+    renderOverrides();
+
+    fireEvent.change(dateField(), { target: { value: '2026-05-01' } });
+    await userEvent.setup().click(saveButton());
+
+    await waitFor(() => expect(upsert).toHaveBeenCalled());
+    expect(shownToast().type).toBe('success');
+    expect(screen.getByText('Special day saved')).toBeInTheDocument();
+    // The form resets, so the next entry does not inherit this date.
+    await waitFor(() => expect(dateField()).toHaveValue(''));
+  });
+
+  it('replaces the entry for a date rather than listing it twice', async () => {
+    const existing = override(1, '2026-01-06T00:00:00Z', 450);
+    upsert.mockResolvedValue(override(1, '2026-01-06T00:00:00Z', 240));
+    renderOverrides([existing]);
+
+    fireEvent.change(dateField(), { target: { value: '2026-01-06' } });
+    await userEvent.setup().click(saveButton());
+
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: /—/ })).toHaveLength(1),
+    );
+  });
+
+  it('reports a refused save', async () => {
+    upsert.mockRejectedValue(new Error('date is in the past'));
+    renderOverrides();
+
+    fireEvent.change(dateField(), { target: { value: '2026-05-01' } });
+    await userEvent.setup().click(saveButton());
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(screen.getByText('Failed to save special day')).toBeInTheDocument();
+    expect(screen.getByText('date is in the past')).toBeInTheDocument();
+  });
+
+  it('removes only the row asked for', async () => {
+    remove.mockResolvedValue(undefined);
+    renderOverrides([
+      override(1, '2026-01-06T00:00:00Z', 450),
+      override(2, '2026-03-10T00:00:00Z', 240),
+    ]);
+
+    await userEvent.setup().click(screen.getAllByTitle('Remove')[0]);
+
+    await waitFor(() => expect(remove).toHaveBeenCalledWith(1));
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: /—/ })).toHaveLength(1),
+    );
+    expect(
+      screen.getByRole('button', { name: /10\.3\.2026/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('reports a refused removal', async () => {
+    remove.mockRejectedValue(new Error('not yours'));
+    renderOverrides([override(1, '2026-01-06T00:00:00Z', 450)]);
+
+    await userEvent.setup().click(screen.getByTitle('Remove'));
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(
+      screen.getByText('Failed to remove special day'),
+    ).toBeInTheDocument();
+  });
+
+  it('loads an existing day back into the form when it is clicked', async () => {
+    renderOverrides([override(1, '2026-01-06T00:00:00Z', 450, 'Short Friday')]);
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: /6\.1\.2026/ }));
+
+    expect(dateField()).toHaveValue('2026-01-06');
+    // 450 minutes split back into 7:30, and the label restored for editing.
+    expect(screen.getByPlaceholderText('hh')).toHaveValue(7);
+    expect(screen.getByPlaceholderText('mm')).toHaveValue(30);
+    expect(screen.getByDisplayValue('Short Friday')).toBeInTheDocument();
+  });
+});

--- a/src/app/settings/__tests__/expectedHoursOverrides.test.tsx
+++ b/src/app/settings/__tests__/expectedHoursOverrides.test.tsx
@@ -47,9 +47,17 @@ const override = (
   label: string | null = null,
 ): ExpectedHoursOverride => ({ id, date: new Date(date), minutes, label });
 
+/**
+ * The toast the component asked for, rendered on its own so its text can be read.
+ *
+ * The returned queries are bound to that render, not to the document — asserting
+ * through `screen` here would also search the component's own tree, so a message that
+ * happened to appear in both would pass for the wrong reason.
+ */
 const shownToast = () => {
   const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
-  return { type: msg.type, ...render(<>{msg.message}</>) };
+  const { getByText } = render(<>{msg.message}</>);
+  return { type: msg.type, getByText };
 };
 
 const renderOverrides = (overrides: ExpectedHoursOverride[] = []) =>
@@ -104,8 +112,9 @@ describe('ExpectedHoursOverrides', () => {
     await userEvent.setup().click(saveButton());
 
     await waitFor(() => expect(upsert).toHaveBeenCalled());
-    expect(shownToast().type).toBe('success');
-    expect(screen.getByText('Special day saved')).toBeInTheDocument();
+    const toast = shownToast();
+    expect(toast.type).toBe('success');
+    expect(toast.getByText('Special day saved')).toBeInTheDocument();
     // The form resets, so the next entry does not inherit this date.
     await waitFor(() => expect(dateField()).toHaveValue(''));
   });
@@ -133,8 +142,8 @@ describe('ExpectedHoursOverrides', () => {
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
     const toast = shownToast();
     expect(toast.type).toBe('error');
-    expect(screen.getByText('Failed to save special day')).toBeInTheDocument();
-    expect(screen.getByText('date is in the past')).toBeInTheDocument();
+    expect(toast.getByText('Failed to save special day')).toBeInTheDocument();
+    expect(toast.getByText('date is in the past')).toBeInTheDocument();
   });
 
   it('removes only the row asked for', async () => {
@@ -164,9 +173,7 @@ describe('ExpectedHoursOverrides', () => {
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
     const toast = shownToast();
     expect(toast.type).toBe('error');
-    expect(
-      screen.getByText('Failed to remove special day'),
-    ).toBeInTheDocument();
+    expect(toast.getByText('Failed to remove special day')).toBeInTheDocument();
   });
 
   it('loads an existing day back into the form when it is clicked', async () => {

--- a/src/app/settings/__tests__/settings.test.tsx
+++ b/src/app/settings/__tests__/settings.test.tsx
@@ -1,0 +1,179 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+import type { Date_Time } from '@/util/dateFormatter';
+import type { Settings as SettingsType } from '@/types';
+
+// Settings decides the whole balance, so its validation is the interesting part: it
+// refuses to save without a begin date or default times, and refuses times in the
+// wrong order. Each of those raises before the action is reached, and each surfaces
+// as a toast — none of which the browser suite can produce, because the form always
+// has valid values in it there.
+jest.mock('@/actions', () => ({ onSettingsUpdate: jest.fn() }));
+
+type UpdateMock = jest.Mock<(data: unknown) => Promise<unknown>>;
+
+let Settings: typeof import('../settings').default;
+let ToastContext: typeof import('@/components/toastContext').ToastContext;
+let update: UpdateMock;
+
+beforeAll(async () => {
+  Settings = (await import('../settings')).default;
+  ToastContext = (await import('@/components/toastContext')).ToastContext;
+  update = (await import('@/actions'))
+    .onSettingsUpdate as unknown as UpdateMock;
+});
+
+const time = (s: string) => s as Date_Time;
+const setMsg = jest.fn<(msg: unknown) => void>();
+
+const settings = (overrides: Partial<SettingsType> = {}): SettingsType => ({
+  id: 1,
+  beginDate: new Date('2026-01-05T00:00:00Z'),
+  initialBalanceHours: 2,
+  initialBalanceMins: 30,
+  fromDefault: time('08:00'),
+  toDefault: time('16:00'),
+  expectedMinutesPerDay: 450,
+  ...overrides,
+});
+
+const shownToast = () => {
+  const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
+  return { type: msg.type, ...render(<>{msg.message}</>) };
+};
+
+const renderSettings = (overrides: Partial<SettingsType> = {}) =>
+  render(
+    <ToastContext.Provider value={{ msg: null, setMsg }}>
+      <Settings settings={settings(overrides)} />
+    </ToastContext.Provider>,
+  );
+
+const submit = () =>
+  userEvent.setup().click(screen.getByRole('button', { name: 'Submit' }));
+
+// Initial balance and expected-per-day both render an hh/mm pair, so the fields are
+// addressed by position: the first pair is the balance, the second the daily figure.
+const hours = (which: 0 | 1) => screen.getAllByPlaceholderText('hh')[which];
+const minutes = (which: 0 | 1) => screen.getAllByPlaceholderText('mm')[which];
+const beginDate = () => screen.getByDisplayValue('2026-01-05');
+
+beforeEach(() => {
+  update.mockReset();
+  setMsg.mockReset();
+});
+
+describe('Settings', () => {
+  it('opens on the values already saved, with expected minutes split into hours', () => {
+    renderSettings();
+
+    expect(hours(0)).toHaveValue(2);
+    expect(minutes(0)).toHaveValue(30);
+    expect(screen.getByDisplayValue('08:00')).toBeInTheDocument();
+    // 450 minutes is 7:30.
+    expect(hours(1)).toHaveValue(7);
+    expect(minutes(1)).toHaveValue(30);
+  });
+
+  it('saves the values as entered', async () => {
+    update.mockResolvedValue(undefined);
+    renderSettings();
+
+    await submit();
+
+    await waitFor(() =>
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialBalanceHours: 2,
+          initialBalanceMins: 30,
+          fromDefault: '08:00',
+          toDefault: '16:00',
+          expectedMinutesPerDay: 450,
+        }),
+      ),
+    );
+    expect(shownToast().type).toBe('success');
+    expect(screen.getByText('Settings saved')).toBeInTheDocument();
+  });
+
+  it('refuses times in the wrong order', async () => {
+    renderSettings({ fromDefault: time('17:00'), toDefault: time('09:00') });
+
+    await submit();
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    expect(update).not.toHaveBeenCalled();
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(
+      screen.getByText('From time must be before to time'),
+    ).toBeInTheDocument();
+  });
+
+  it('refuses to save without a begin date', async () => {
+    renderSettings();
+    // user.clear() does not fire a change on a date input in jsdom, so the empty
+    // value is set directly — the same event the browser sends.
+    fireEvent.change(beginDate(), { target: { value: '' } });
+
+    await submit();
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    expect(update).not.toHaveBeenCalled();
+    shownToast();
+    expect(screen.getByText('Begin date is required')).toBeInTheDocument();
+  });
+
+  it('treats cleared numbers as zero rather than refusing', async () => {
+    update.mockResolvedValue(undefined);
+    renderSettings();
+    const user = userEvent.setup();
+    await user.clear(hours(0));
+    await user.clear(minutes(0));
+
+    await submit();
+
+    await waitFor(() =>
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialBalanceHours: 0,
+          initialBalanceMins: 0,
+        }),
+      ),
+    );
+  });
+
+  it('reports a failure from the server', async () => {
+    update.mockRejectedValue(new Error('database unavailable'));
+    renderSettings();
+
+    await submit();
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(screen.getByText('Failed to save settings')).toBeInTheDocument();
+    expect(screen.getByText('database unavailable')).toBeInTheDocument();
+  });
+
+  it('omits a detail line when the failure carries no message', async () => {
+    update.mockRejectedValue('a bare string');
+    renderSettings();
+
+    await submit();
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    shownToast();
+    expect(screen.getByText('Failed to save settings')).toBeInTheDocument();
+  });
+});

--- a/src/app/settings/__tests__/settings.test.tsx
+++ b/src/app/settings/__tests__/settings.test.tsx
@@ -47,9 +47,17 @@ const settings = (overrides: Partial<SettingsType> = {}): SettingsType => ({
   ...overrides,
 });
 
+/**
+ * The toast the component asked for, rendered on its own so its text can be read.
+ *
+ * The returned queries are bound to that render, not to the document — asserting
+ * through `screen` here would also search the component's own tree, so a message that
+ * happened to appear in both would pass for the wrong reason.
+ */
 const shownToast = () => {
   const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
-  return { type: msg.type, ...render(<>{msg.message}</>) };
+  const { getByText } = render(<>{msg.message}</>);
+  return { type: msg.type, getByText };
 };
 
 const renderSettings = (overrides: Partial<SettingsType> = {}) =>
@@ -102,8 +110,9 @@ describe('Settings', () => {
         }),
       ),
     );
-    expect(shownToast().type).toBe('success');
-    expect(screen.getByText('Settings saved')).toBeInTheDocument();
+    const toast = shownToast();
+    expect(toast.type).toBe('success');
+    expect(toast.getByText('Settings saved')).toBeInTheDocument();
   });
 
   it('refuses times in the wrong order', async () => {
@@ -116,7 +125,7 @@ describe('Settings', () => {
     const toast = shownToast();
     expect(toast.type).toBe('error');
     expect(
-      screen.getByText('From time must be before to time'),
+      toast.getByText('From time must be before to time'),
     ).toBeInTheDocument();
   });
 
@@ -130,8 +139,8 @@ describe('Settings', () => {
 
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
     expect(update).not.toHaveBeenCalled();
-    shownToast();
-    expect(screen.getByText('Begin date is required')).toBeInTheDocument();
+    const toast = shownToast();
+    expect(toast.getByText('Begin date is required')).toBeInTheDocument();
   });
 
   it('treats cleared numbers as zero rather than refusing', async () => {
@@ -162,8 +171,8 @@ describe('Settings', () => {
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
     const toast = shownToast();
     expect(toast.type).toBe('error');
-    expect(screen.getByText('Failed to save settings')).toBeInTheDocument();
-    expect(screen.getByText('database unavailable')).toBeInTheDocument();
+    expect(toast.getByText('Failed to save settings')).toBeInTheDocument();
+    expect(toast.getByText('database unavailable')).toBeInTheDocument();
   });
 
   it('omits a detail line when the failure carries no message', async () => {
@@ -173,7 +182,7 @@ describe('Settings', () => {
     await submit();
 
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
-    shownToast();
-    expect(screen.getByText('Failed to save settings')).toBeInTheDocument();
+    const toast = shownToast();
+    expect(toast.getByText('Failed to save settings')).toBeInTheDocument();
   });
 });

--- a/src/app/statistics/__tests__/workMinutesPerDayChart.test.tsx
+++ b/src/app/statistics/__tests__/workMinutesPerDayChart.test.tsx
@@ -1,0 +1,88 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import type { TooltipItem } from 'chart.js/auto';
+
+// Chart.js draws to a canvas jsdom does not implement, so the chart component is
+// asserted through the data and options it hands the renderer. Those are the parts
+// with logic in them: the days are sorted before plotting, minutes are converted to
+// hours, and the tooltip formats the x value as a date.
+jest.mock('react-chartjs-2', () => ({
+  Line: (props: { data: unknown; options: unknown }) => (
+    <div data-testid="line-chart" data-chart={JSON.stringify(props.data)} />
+  ),
+}));
+
+let WorkMinutesPerDayChart: typeof import('../workMinutesPerDayChart').default;
+let options: typeof import('../workMinutesPerDayChart').options;
+
+beforeAll(async () => {
+  const mod = await import('../workMinutesPerDayChart');
+  WorkMinutesPerDayChart = mod.default;
+  options = mod.options;
+});
+
+type ChartData = { labels: string[]; datasets: { data: number[] }[] };
+
+const plotted = (): ChartData =>
+  JSON.parse(
+    screen.getByTestId('line-chart').getAttribute('data-chart') ?? '{}',
+  ) as ChartData;
+
+describe('WorkMinutesPerDayChart', () => {
+  it('plots the days in order however the map was built', () => {
+    render(
+      <WorkMinutesPerDayChart
+        workMinutesPerDay={
+          new Map([
+            ['2026-03-02', 480],
+            ['2026-01-05', 450],
+            ['2026-02-01', 300],
+          ])
+        }
+      />,
+    );
+
+    expect(plotted().labels).toEqual([
+      '2026-01-05',
+      '2026-02-01',
+      '2026-03-02',
+    ]);
+  });
+
+  it('plots hours rather than the minutes it is given', () => {
+    render(
+      <WorkMinutesPerDayChart
+        workMinutesPerDay={new Map([['2026-01-05', 450]])}
+      />,
+    );
+
+    // 450 minutes is 7.5 hours; plotting raw minutes would put the axis out by 60x.
+    expect(plotted().datasets[0].data).toEqual([7.5]);
+  });
+
+  it('renders an empty chart for a range with no work', () => {
+    render(<WorkMinutesPerDayChart workMinutesPerDay={new Map()} />);
+
+    expect(plotted().labels).toEqual([]);
+  });
+});
+
+describe('chart options', () => {
+  // Read inside the tests: the module is imported in beforeAll, which runs after the
+  // describe body.
+  const title = () => options.plugins.tooltip.callbacks.title;
+
+  it('shows the hovered point as a date', () => {
+    const point = [
+      { parsed: { x: Date.parse('2026-01-05T00:00:00Z') } },
+    ] as unknown as TooltipItem<'line'>[];
+
+    expect(title()(point)).toBe('5.1.2026');
+  });
+
+  it('says nothing when the point carries no date', () => {
+    const point = [{ parsed: { x: null } }] as unknown as TooltipItem<'line'>[];
+
+    expect(title()(point)).toBe('');
+  });
+});

--- a/src/app/worklog-entry/__tests__/dayExpectedOverride.test.tsx
+++ b/src/app/worklog-entry/__tests__/dayExpectedOverride.test.tsx
@@ -1,0 +1,200 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+import type { Date_ISODay } from '@/util/dateFormatter';
+import type { ExpectedHoursOverride } from '@/types';
+
+// Setting a day's expected hours from the day view. Two rules live here and nowhere
+// else: Clear is offered only when there is something to clear, and opening the
+// dialog resets the fields to the day's current values so a cancelled edit does not
+// linger and get saved by accident next time.
+jest.mock('@/actions', () => ({
+  onExpectedHoursOverrideUpsert: jest.fn(),
+  onExpectedHoursOverrideDelete: jest.fn(),
+}));
+jest.mock('@/components/modal', () => {
+  const actual =
+    jest.requireActual<typeof import('@/components/modal')>(
+      '@/components/modal',
+    );
+  return {
+    __esModule: true,
+    default: actual.default,
+    showModal: jest.fn(),
+    closeModal: jest.fn(),
+  };
+});
+
+type ActionMock = jest.Mock<(...args: unknown[]) => Promise<unknown>>;
+
+let DayExpectedOverride: typeof import('../dayExpectedOverride').default;
+let ToastContext: typeof import('@/components/toastContext').ToastContext;
+let upsert: ActionMock;
+let remove: ActionMock;
+
+beforeAll(async () => {
+  DayExpectedOverride = (await import('../dayExpectedOverride')).default;
+  ToastContext = (await import('@/components/toastContext')).ToastContext;
+  const actions = await import('@/actions');
+  upsert = actions.onExpectedHoursOverrideUpsert as unknown as ActionMock;
+  remove = actions.onExpectedHoursOverrideDelete as unknown as ActionMock;
+});
+
+const day = '2026-07-26' as Date_ISODay;
+const setMsg = jest.fn<(msg: unknown) => void>();
+
+const shownToast = () => {
+  const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
+  return { type: msg.type, ...render(<>{msg.message}</>) };
+};
+
+const renderOverride = (
+  override: ExpectedHoursOverride | null = null,
+  expectedMinutes = 450,
+) =>
+  render(
+    <ToastContext.Provider value={{ msg: null, setMsg }}>
+      <DayExpectedOverride
+        day={day}
+        expectedMinutes={expectedMinutes}
+        override={override}
+      />
+    </ToastContext.Provider>,
+  );
+
+const button = (name: string) =>
+  screen.getByRole('button', { name, hidden: true });
+
+beforeEach(() => {
+  upsert.mockReset();
+  remove.mockReset();
+  setMsg.mockReset();
+});
+
+describe('DayExpectedOverride', () => {
+  it('shows the day expectation, marking it when it is custom', () => {
+    const { unmount } = renderOverride();
+    expect(screen.getByText(/Expected today: 7h 30min/)).toBeInTheDocument();
+    expect(screen.queryByText(/custom/)).not.toBeInTheDocument();
+    unmount();
+
+    renderOverride(
+      {
+        id: 1,
+        date: new Date('2026-07-26T00:00:00Z'),
+        minutes: 240,
+        label: 'Short day',
+      },
+      240,
+    );
+    expect(screen.getByText(/custom/)).toBeInTheDocument();
+  });
+
+  it('offers Clear only when there is an override to clear', () => {
+    const { unmount } = renderOverride();
+    expect(
+      screen.queryByRole('button', { name: 'Clear', hidden: true }),
+    ).toBeNull();
+    unmount();
+
+    renderOverride(
+      {
+        id: 1,
+        date: new Date('2026-07-26T00:00:00Z'),
+        minutes: 240,
+        label: null,
+      },
+      240,
+    );
+    expect(button('Clear')).toBeInTheDocument();
+  });
+
+  it('resets the fields to the day when reopened', async () => {
+    renderOverride(null, 450);
+    const user = userEvent.setup();
+
+    // Type something, then reopen without saving.
+    await user.clear(screen.getByPlaceholderText('hh'));
+    await user.type(screen.getByPlaceholderText('hh'), '3');
+    expect(screen.getByPlaceholderText('hh')).toHaveValue(3);
+
+    await user.click(screen.getByTitle('Edit'));
+
+    // Back to the day's real expectation, so a cancelled edit cannot be saved later.
+    expect(screen.getByPlaceholderText('hh')).toHaveValue(7);
+    expect(screen.getByPlaceholderText('mm')).toHaveValue(30);
+  });
+
+  it('saves the day expectation', async () => {
+    upsert.mockResolvedValue(undefined);
+    renderOverride();
+
+    await userEvent.setup().click(button('Save'));
+
+    await waitFor(() => expect(upsert).toHaveBeenCalled());
+    expect(shownToast().type).toBe('success');
+    expect(screen.getByText('Expected hours updated')).toBeInTheDocument();
+  });
+
+  it('reports a refused save', async () => {
+    upsert.mockRejectedValue(new Error('not allowed'));
+    renderOverride();
+
+    await userEvent.setup().click(button('Save'));
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(
+      screen.getByText('Failed to update expected hours'),
+    ).toBeInTheDocument();
+  });
+
+  it('clears an existing override', async () => {
+    remove.mockResolvedValue(undefined);
+    renderOverride(
+      {
+        id: 7,
+        date: new Date('2026-07-26T00:00:00Z'),
+        minutes: 240,
+        label: null,
+      },
+      240,
+    );
+
+    await userEvent.setup().click(button('Clear'));
+
+    await waitFor(() => expect(remove).toHaveBeenCalledWith(7));
+    expect(shownToast().type).toBe('success');
+    expect(screen.getByText('Override cleared')).toBeInTheDocument();
+  });
+
+  it('reports a refused clear', async () => {
+    remove.mockRejectedValue(new Error('already gone'));
+    renderOverride(
+      {
+        id: 7,
+        date: new Date('2026-07-26T00:00:00Z'),
+        minutes: 240,
+        label: null,
+      },
+      240,
+    );
+
+    await userEvent.setup().click(button('Clear'));
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(screen.getByText('Failed to clear override')).toBeInTheDocument();
+  });
+});

--- a/src/app/worklog-entry/__tests__/dayExpectedOverride.test.tsx
+++ b/src/app/worklog-entry/__tests__/dayExpectedOverride.test.tsx
@@ -52,9 +52,17 @@ beforeAll(async () => {
 const day = '2026-07-26' as Date_ISODay;
 const setMsg = jest.fn<(msg: unknown) => void>();
 
+/**
+ * The toast the component asked for, rendered on its own so its text can be read.
+ *
+ * The returned queries are bound to that render, not to the document — asserting
+ * through `screen` here would also search the component's own tree, so a message that
+ * happened to appear in both would pass for the wrong reason.
+ */
 const shownToast = () => {
   const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
-  return { type: msg.type, ...render(<>{msg.message}</>) };
+  const { getByText } = render(<>{msg.message}</>);
+  return { type: msg.type, getByText };
 };
 
 const renderOverride = (
@@ -141,8 +149,9 @@ describe('DayExpectedOverride', () => {
     await userEvent.setup().click(button('Save'));
 
     await waitFor(() => expect(upsert).toHaveBeenCalled());
-    expect(shownToast().type).toBe('success');
-    expect(screen.getByText('Expected hours updated')).toBeInTheDocument();
+    const toast = shownToast();
+    expect(toast.type).toBe('success');
+    expect(toast.getByText('Expected hours updated')).toBeInTheDocument();
   });
 
   it('reports a refused save', async () => {
@@ -155,7 +164,7 @@ describe('DayExpectedOverride', () => {
     const toast = shownToast();
     expect(toast.type).toBe('error');
     expect(
-      screen.getByText('Failed to update expected hours'),
+      toast.getByText('Failed to update expected hours'),
     ).toBeInTheDocument();
   });
 
@@ -174,8 +183,9 @@ describe('DayExpectedOverride', () => {
     await userEvent.setup().click(button('Clear'));
 
     await waitFor(() => expect(remove).toHaveBeenCalledWith(7));
-    expect(shownToast().type).toBe('success');
-    expect(screen.getByText('Override cleared')).toBeInTheDocument();
+    const toast = shownToast();
+    expect(toast.type).toBe('success');
+    expect(toast.getByText('Override cleared')).toBeInTheDocument();
   });
 
   it('reports a refused clear', async () => {
@@ -195,6 +205,6 @@ describe('DayExpectedOverride', () => {
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
     const toast = shownToast();
     expect(toast.type).toBe('error');
-    expect(screen.getByText('Failed to clear override')).toBeInTheDocument();
+    expect(toast.getByText('Failed to clear override')).toBeInTheDocument();
   });
 });

--- a/src/app/worklog-entry/__tests__/existingWorklogs.test.tsx
+++ b/src/app/worklog-entry/__tests__/existingWorklogs.test.tsx
@@ -1,0 +1,54 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import type { Worklog } from '@/types';
+
+// A thin wrapper, but it holds the day's total — the figure a user checks before
+// deciding whether they still owe time today. It also renders nothing at all for an
+// empty day rather than an empty heading with a zero badge.
+jest.mock('@/components/worklogItem/worklogItem', () => ({
+  __esModule: true,
+  default: ({ worklog }: { worklog: Worklog }) => <div>row-{worklog.id}</div>,
+}));
+
+let ExistingWorklogs: typeof import('../existingWorklogs').default;
+
+beforeAll(async () => {
+  ExistingWorklogs = (await import('../existingWorklogs')).default;
+});
+
+const worklog = (id: number, hours: number): Worklog => ({
+  id,
+  from: new Date('2026-07-26T08:00:00Z'),
+  to: new Date(`2026-07-26T${String(8 + hours).padStart(2, '0')}:00:00Z`),
+  subtractLunchBreak: false,
+  absence: null,
+  comment: null,
+});
+
+const renderList = (worklogs: Worklog[]) =>
+  render(
+    <ExistingWorklogs
+      worklogs={worklogs}
+      onDelete={jest.fn()}
+      onEdit={jest.fn()}
+    />,
+  );
+
+describe('ExistingWorklogs', () => {
+  it('renders nothing for a day with no entries', () => {
+    const { container } = renderList([]);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('lists the entries and totals their time', () => {
+    renderList([worklog(1, 3), worklog(2, 5)]);
+
+    expect(screen.getByText('Existing worklogs for day')).toBeInTheDocument();
+    expect(screen.getByText('row-1')).toBeInTheDocument();
+    expect(screen.getByText('row-2')).toBeInTheDocument();
+    // Three hours plus five, shown as the day's running total.
+    expect(screen.getByText('8h 0min')).toBeInTheDocument();
+  });
+});

--- a/src/app/worklog-entry/__tests__/worklogEntry.test.tsx
+++ b/src/app/worklog-entry/__tests__/worklogEntry.test.tsx
@@ -1,0 +1,180 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+import type { Date_ISODay, Date_Time } from '@/util/dateFormatter';
+import type { Worklog, WorklogFormData } from '@/types';
+
+// The day view's own work is turning the form's day-and-time strings into real dates
+// before submitting, keeping the day's list current afterwards, and offering the
+// neighbouring days. The submit path validates first: a malformed time raises before
+// the action is reached, which the browser suite cannot produce because the inputs
+// only ever hold valid values there.
+//
+// The children are stubbed to what this component actually interacts with; each has
+// its own test.
+jest.mock('../dayExpectedOverride', () => ({
+  __esModule: true,
+  default: () => <div>expected-override</div>,
+}));
+jest.mock('../existingWorklogs', () => ({
+  __esModule: true,
+  default: ({
+    worklogs,
+    onDelete,
+  }: {
+    worklogs: Worklog[];
+    onDelete: (id: number) => void;
+  }) => (
+    <div>
+      <span>existing:{worklogs.length}</span>
+      {worklogs.map((w) => (
+        <button key={w.id} onClick={() => onDelete(w.id)}>
+          drop-{w.id}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+let WorklogEntry: typeof import('../worklogEntry').default;
+let ToastContext: typeof import('@/components/toastContext').ToastContext;
+
+beforeAll(async () => {
+  WorklogEntry = (await import('../worklogEntry')).default;
+  ToastContext = (await import('@/components/toastContext')).ToastContext;
+});
+
+const day = '2026-07-26' as Date_ISODay;
+const time = (s: string) => s as Date_Time;
+const setMsg = jest.fn<(msg: unknown) => void>();
+const onSubmit = jest.fn<(value: WorklogFormData) => Promise<Worklog>>();
+
+const created = (id: number): Worklog => ({
+  id,
+  from: new Date('2026-07-26T08:00:00Z'),
+  to: new Date('2026-07-26T16:00:00Z'),
+  subtractLunchBreak: false,
+  absence: null,
+  comment: null,
+});
+
+const shownToast = () => {
+  const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
+  return { type: msg.type, ...render(<>{msg.message}</>) };
+};
+
+const renderEntry = (worklogs: Worklog[] = []) =>
+  render(
+    <ToastContext.Provider value={{ msg: null, setMsg }}>
+      <WorklogEntry
+        day={day}
+        defaults={{ fromDefault: time('08:00'), toDefault: time('16:00') }}
+        worklogs={worklogs}
+        onSubmit={onSubmit}
+        expectedMinutes={450}
+        override={null}
+      />
+    </ToastContext.Provider>,
+  );
+
+const submit = () =>
+  userEvent.setup().click(screen.getByRole('button', { name: 'Submit' }));
+
+beforeEach(() => {
+  onSubmit.mockReset();
+  setMsg.mockReset();
+});
+
+describe('WorklogEntry', () => {
+  it('offers the neighbouring days', () => {
+    renderEntry();
+
+    expect(screen.getByTitle('Yesterday').closest('a')).toHaveAttribute(
+      'href',
+      '/worklog-entry?day=2026-07-25',
+    );
+    expect(screen.getByTitle('Tomorrow').closest('a')).toHaveAttribute(
+      'href',
+      '/worklog-entry?day=2026-07-27',
+    );
+  });
+
+  it('shows the day it is editing and the entries already on it', () => {
+    renderEntry([created(1)]);
+
+    expect(screen.getByText('26.7.2026')).toBeInTheDocument();
+    expect(screen.getByText('existing:1')).toBeInTheDocument();
+  });
+
+  it('submits the form times as dates on that day', async () => {
+    onSubmit.mockResolvedValue(created(9));
+    renderEntry();
+
+    await submit();
+
+    // The day and the times arrive as separate strings and have to be combined; a
+    // worklog stamped on the wrong day is the failure this guards.
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(submitted.from.toISOString()).toContain('2026-07-26');
+    expect(submitted.to.toISOString()).toContain('2026-07-26');
+    expect(shownToast().type).toBe('success');
+    expect(screen.getByText('Worklog created')).toBeInTheDocument();
+  });
+
+  it('adds what was created to the day without a reload', async () => {
+    onSubmit.mockResolvedValue(created(9));
+    renderEntry();
+    expect(screen.getByText('existing:0')).toBeInTheDocument();
+
+    await submit();
+
+    expect(await screen.findByText('existing:1')).toBeInTheDocument();
+  });
+
+  it('reports the reason when the server refuses', async () => {
+    onSubmit.mockRejectedValue(new Error('overlaps an existing worklog'));
+    renderEntry();
+
+    await submit();
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(screen.getByText('Failed to create worklog')).toBeInTheDocument();
+    expect(
+      screen.getByText('overlaps an existing worklog'),
+    ).toBeInTheDocument();
+  });
+
+  it('omits a detail line when the failure carries no message', async () => {
+    onSubmit.mockRejectedValue('a bare string');
+    renderEntry();
+
+    await submit();
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    shownToast();
+    expect(screen.getByText('Failed to create worklog')).toBeInTheDocument();
+  });
+
+  it('takes a removed entry out of the day', async () => {
+    renderEntry([created(1), created(2)]);
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: 'drop-1' }));
+
+    expect(screen.getByText('existing:1')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'drop-1' })).toBeNull();
+  });
+});

--- a/src/app/worklog-entry/__tests__/worklogEntry.test.tsx
+++ b/src/app/worklog-entry/__tests__/worklogEntry.test.tsx
@@ -67,9 +67,17 @@ const created = (id: number): Worklog => ({
   comment: null,
 });
 
+/**
+ * The toast the component asked for, rendered on its own so its text can be read.
+ *
+ * The returned queries are bound to that render, not to the document — asserting
+ * through `screen` here would also search the component's own tree, so a message that
+ * happened to appear in both would pass for the wrong reason.
+ */
 const shownToast = () => {
   const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
-  return { type: msg.type, ...render(<>{msg.message}</>) };
+  const { getByText } = render(<>{msg.message}</>);
+  return { type: msg.type, getByText };
 };
 
 const renderEntry = (worklogs: Worklog[] = []) =>
@@ -127,8 +135,9 @@ describe('WorklogEntry', () => {
     const submitted = onSubmit.mock.calls[0][0];
     expect(submitted.from.toISOString()).toContain('2026-07-26');
     expect(submitted.to.toISOString()).toContain('2026-07-26');
-    expect(shownToast().type).toBe('success');
-    expect(screen.getByText('Worklog created')).toBeInTheDocument();
+    const toast = shownToast();
+    expect(toast.type).toBe('success');
+    expect(toast.getByText('Worklog created')).toBeInTheDocument();
   });
 
   it('adds what was created to the day without a reload', async () => {
@@ -150,10 +159,8 @@ describe('WorklogEntry', () => {
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
     const toast = shownToast();
     expect(toast.type).toBe('error');
-    expect(screen.getByText('Failed to create worklog')).toBeInTheDocument();
-    expect(
-      screen.getByText('overlaps an existing worklog'),
-    ).toBeInTheDocument();
+    expect(toast.getByText('Failed to create worklog')).toBeInTheDocument();
+    expect(toast.getByText('overlaps an existing worklog')).toBeInTheDocument();
   });
 
   it('omits a detail line when the failure carries no message', async () => {
@@ -163,8 +170,8 @@ describe('WorklogEntry', () => {
     await submit();
 
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
-    shownToast();
-    expect(screen.getByText('Failed to create worklog')).toBeInTheDocument();
+    const toast = shownToast();
+    expect(toast.getByText('Failed to create worklog')).toBeInTheDocument();
   });
 
   it('takes a removed entry out of the day', async () => {

--- a/src/app/worklog-items/__tests__/worklogItems.test.tsx
+++ b/src/app/worklog-items/__tests__/worklogItems.test.tsx
@@ -121,7 +121,26 @@ describe('WorklogItems', () => {
     expect(screen.getByTestId('row-2')).toHaveAttribute('data-ignored', 'no');
   });
 
-  it('drops a deleted row once the server data catches up', async () => {
+  it('drops a deleted row straight away', async () => {
+    const both = [
+      worklog(1, dayOffset(-1), 'first'),
+      worklog(2, dayOffset(-1), 'second'),
+    ];
+    render(
+      <WorklogItems worklogs={both} settings={settings(dayOffset(-90))} />,
+    );
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: 'delete-1' }));
+
+    // No waiting for the server: the row goes now. This is what the resync used to
+    // undo, by reading a shorter local list as a new server list.
+    expect(screen.queryByTestId('row-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('row-2')).toBeInTheDocument();
+  });
+
+  it('restores a row the server still reports after a failed delete', async () => {
     const both = [
       worklog(1, dayOffset(-1), 'first'),
       worklog(2, dayOffset(-1), 'second'),
@@ -133,20 +152,15 @@ describe('WorklogItems', () => {
     await userEvent
       .setup()
       .click(screen.getByRole('button', { name: 'delete-1' }));
+    expect(screen.queryByTestId('row-1')).not.toBeInTheDocument();
 
-    // Documenting current behaviour, not endorsing it: the local removal is undone
-    // immediately, because the length resync sees `worklogs` still holding two and
-    // overwrites the shortened state. The row only goes when router.refresh() has
-    // re-rendered the parent with one fewer worklog — so the optimistic update is
-    // dead code and the refresh is what the user actually waits for.
-    expect(screen.getByTestId('row-1')).toBeInTheDocument();
-
+    // The refresh brings back a list that still has it, and the server wins — the
+    // optimistic removal must not outlive a delete that did not happen.
     rerender(
-      <WorklogItems worklogs={[both[1]]} settings={settings(dayOffset(-90))} />,
+      <WorklogItems worklogs={[...both]} settings={settings(dayOffset(-90))} />,
     );
 
-    expect(screen.queryByTestId('row-1')).not.toBeInTheDocument();
-    expect(screen.getByTestId('row-2')).toBeInTheDocument();
+    expect(screen.getByTestId('row-1')).toBeInTheDocument();
   });
 
   it('shows the new value of an edited row in place', async () => {

--- a/src/app/worklog-items/__tests__/worklogItems.test.tsx
+++ b/src/app/worklog-items/__tests__/worklogItems.test.tsx
@@ -1,0 +1,191 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { Date_Time } from '@/util/dateFormatter';
+import type { Settings, Worklog } from '@/types';
+
+// This component's own work is grouping: by day, then by month, with anything ahead
+// of today held in a separate "Future worklogs" group and anything before the begin
+// date dimmed because it does not count. Those rules decide what a user believes
+// their history is, and none of them are visible to a test that only reads one month.
+//
+// WorklogItem is stubbed down to the two callbacks it invokes, so the local-state
+// bookkeeping after a delete or an edit can be driven directly. The row itself has
+// its own test.
+jest.mock('@/components/worklogItem/worklogItem', () => ({
+  __esModule: true,
+  default: ({
+    worklog,
+    ignored,
+    onDelete,
+    onEdit,
+  }: {
+    worklog: Worklog;
+    ignored?: boolean;
+    onDelete: (id: number) => void;
+    onEdit: (edited: Worklog) => void;
+  }) => (
+    <div
+      data-testid={`row-${worklog.id}`}
+      data-ignored={ignored ? 'yes' : 'no'}
+    >
+      <span>{worklog.comment}</span>
+      <button onClick={() => onDelete(worklog.id)}>delete-{worklog.id}</button>
+      <button onClick={() => onEdit({ ...worklog, comment: 'edited' })}>
+        edit-{worklog.id}
+      </button>
+    </div>
+  ),
+}));
+
+let WorklogItems: typeof import('../worklogItems').default;
+
+beforeAll(async () => {
+  WorklogItems = (await import('../worklogItems')).default;
+});
+
+const time = (s: string) => s as Date_Time;
+
+/** A day offset from today, at a fixed hour so the entry is comfortably inside it. */
+const dayOffset = (days: number, hour = 9) => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  d.setUTCHours(hour, 0, 0, 0);
+  return d;
+};
+
+const worklog = (id: number, from: Date, comment: string): Worklog => ({
+  id,
+  from,
+  to: new Date(from.getTime() + 8 * 60 * 60 * 1000),
+  subtractLunchBreak: false,
+  absence: null,
+  comment,
+});
+
+const settings = (beginDate: Date): Settings => ({
+  id: 1,
+  beginDate,
+  initialBalanceHours: 0,
+  initialBalanceMins: 0,
+  fromDefault: time('08:00'),
+  toDefault: time('16:00'),
+  expectedMinutesPerDay: 450,
+});
+
+describe('WorklogItems', () => {
+  it('keeps entries ahead of today out of the monthly groups', () => {
+    render(
+      <WorklogItems
+        worklogs={[
+          worklog(1, dayOffset(-1), 'yesterday'),
+          worklog(2, dayOffset(30), 'next month'),
+        ]}
+        settings={settings(dayOffset(-90))}
+      />,
+    );
+
+    expect(screen.getByText('Future worklogs')).toBeInTheDocument();
+    expect(screen.getByTestId('row-1')).toBeInTheDocument();
+    expect(screen.getByTestId('row-2')).toBeInTheDocument();
+  });
+
+  it('groups several entries on one day together', () => {
+    render(
+      <WorklogItems
+        worklogs={[
+          worklog(1, dayOffset(-1, 8), 'morning'),
+          worklog(2, dayOffset(-1, 13), 'afternoon'),
+        ]}
+        settings={settings(dayOffset(-90))}
+      />,
+    );
+
+    // One date badge for the day, two rows under it.
+    expect(screen.getAllByTestId(/^row-/)).toHaveLength(2);
+  });
+
+  it('dims a day that falls before the balance began', () => {
+    render(
+      <WorklogItems
+        worklogs={[
+          worklog(1, dayOffset(-30), 'before'),
+          worklog(2, dayOffset(-1), 'after'),
+        ]}
+        settings={settings(dayOffset(-7))}
+      />,
+    );
+
+    expect(screen.getByTestId('row-1')).toHaveAttribute('data-ignored', 'yes');
+    expect(screen.getByTestId('row-2')).toHaveAttribute('data-ignored', 'no');
+  });
+
+  it('drops a deleted row once the server data catches up', async () => {
+    const both = [
+      worklog(1, dayOffset(-1), 'first'),
+      worklog(2, dayOffset(-1), 'second'),
+    ];
+    const { rerender } = render(
+      <WorklogItems worklogs={both} settings={settings(dayOffset(-90))} />,
+    );
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: 'delete-1' }));
+
+    // Documenting current behaviour, not endorsing it: the local removal is undone
+    // immediately, because the length resync sees `worklogs` still holding two and
+    // overwrites the shortened state. The row only goes when router.refresh() has
+    // re-rendered the parent with one fewer worklog — so the optimistic update is
+    // dead code and the refresh is what the user actually waits for.
+    expect(screen.getByTestId('row-1')).toBeInTheDocument();
+
+    rerender(
+      <WorklogItems worklogs={[both[1]]} settings={settings(dayOffset(-90))} />,
+    );
+
+    expect(screen.queryByTestId('row-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('row-2')).toBeInTheDocument();
+  });
+
+  it('shows the new value of an edited row in place', async () => {
+    render(
+      <WorklogItems
+        worklogs={[worklog(1, dayOffset(-1), 'before edit')]}
+        settings={settings(dayOffset(-90))}
+      />,
+    );
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: 'edit-1' }));
+
+    expect(screen.getByText('edited')).toBeInTheDocument();
+    expect(screen.queryByText('before edit')).not.toBeInTheDocument();
+  });
+
+  it('picks up an entry added elsewhere on the page', () => {
+    const { rerender } = render(
+      <WorklogItems
+        worklogs={[worklog(1, dayOffset(-1), 'first')]}
+        settings={settings(dayOffset(-90))}
+      />,
+    );
+    expect(screen.getAllByTestId(/^row-/)).toHaveLength(1);
+
+    // Quick-add inserts a worklog without remounting this list, which is what the
+    // length resync in the component exists for.
+    rerender(
+      <WorklogItems
+        worklogs={[
+          worklog(1, dayOffset(-1), 'first'),
+          worklog(2, dayOffset(-1), 'added by quick-add'),
+        ]}
+        settings={settings(dayOffset(-90))}
+      />,
+    );
+
+    expect(screen.getAllByTestId(/^row-/)).toHaveLength(2);
+  });
+});

--- a/src/app/worklog-items/worklogItems.tsx
+++ b/src/app/worklog-items/worklogItems.tsx
@@ -99,9 +99,17 @@ export default function WorklogItems({
 }) {
   const [wl, setWl] = useState<Worklog[]>(worklogs);
 
-  if (worklogs.length !== wl.length) {
-    // Don't really understand why this is required but without this
-    // new worklog added with QuickAdd modal isn't shown without refresh
+  // Adopt the server's list whenever a new one arrives. Quick-add inserts a worklog
+  // and refreshes the route without remounting this component, so without this the
+  // new entry would not appear until a full reload.
+  //
+  // The comparison is against the previous *prop*, not against `wl`. Comparing
+  // lengths made any local edit that changed the count — deleting a row — look like
+  // a new server list, so the removal was overwritten on the very next render and
+  // the row reappeared until the refresh landed.
+  const [lastFromServer, setLastFromServer] = useState<Worklog[]>(worklogs);
+  if (worklogs !== lastFromServer) {
+    setLastFromServer(worklogs);
     setWl(worklogs);
   }
 

--- a/src/auth/__tests__/authActions.test.tsx
+++ b/src/auth/__tests__/authActions.test.tsx
@@ -1,0 +1,92 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Session } from 'next-auth';
+
+// The signed-in corner of the navbar. Its two jobs are showing who is signed in —
+// an OAuth avatar where there is one, a placeholder icon otherwise — and signing
+// out. next-auth/react is mocked because its real entry pulls in the ESM-only
+// openid-client.
+jest.mock('next-auth/react', () => ({ signOut: jest.fn() }));
+
+type SignOutMock = jest.Mock<() => Promise<unknown>>;
+
+let AuthActions: typeof import('../authActions').default;
+let signOut: SignOutMock;
+
+beforeAll(async () => {
+  AuthActions = (await import('../authActions')).default;
+  signOut = (await import('next-auth/react')).signOut as unknown as SignOutMock;
+});
+
+const session = (user: {
+  name?: string | null;
+  image?: string | null;
+}): Session => ({ user, expires: '2099-01-01T00:00:00Z' }) as Session;
+
+beforeEach(() => {
+  signOut.mockReset();
+});
+
+describe('AuthActions', () => {
+  it('shows the profile picture a provider supplied', () => {
+    render(
+      <AuthActions
+        session={session({
+          name: 'Ada',
+          image: 'https://example.com/ada.png',
+        })}
+        className="icon"
+      />,
+    );
+
+    expect(screen.getByAltText('Profile picture')).toBeInTheDocument();
+    expect(screen.getByTitle('Ada')).toBeInTheDocument();
+  });
+
+  it('falls back to a placeholder for an account with no picture', () => {
+    render(
+      <AuthActions
+        session={session({ name: 'Ada', image: null })}
+        className="icon"
+      />,
+    );
+
+    expect(screen.queryByAltText('Profile picture')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Ada')).toBeInTheDocument();
+  });
+
+  it('tolerates an account with no name', () => {
+    render(
+      <AuthActions
+        session={session({ name: null, image: null })}
+        className="icon"
+      />,
+    );
+
+    // The nullish coalescing matters: without it the literal "null" would appear as
+    // the tooltip next to the sign-out control.
+    expect(screen.queryByTitle('null')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Sign out')).toBeInTheDocument();
+  });
+
+  it('signs out when asked', async () => {
+    render(
+      <AuthActions
+        session={session({ name: 'Ada', image: null })}
+        className="icon"
+      />,
+    );
+
+    await userEvent.setup().click(screen.getByTitle('Sign out'));
+
+    expect(signOut).toHaveBeenCalled();
+  });
+});

--- a/src/auth/__tests__/authProvider.test.tsx
+++ b/src/auth/__tests__/authProvider.test.tsx
@@ -1,0 +1,69 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import type { Session } from 'next-auth';
+
+// AuthProvider is the root wrapper every page renders inside: it hands the session to
+// next-auth's provider and puts the toast context around the tree. If either were
+// dropped, every page would still render while useSession and every toast silently
+// stopped working — so what is asserted is that both wrappers are present and the
+// session reaches the one that needs it.
+//
+// SessionProvider is stubbed to report the session it was given; the real one pulls
+// in the ESM-only openid-client.
+jest.mock('next-auth/react', () => ({
+  SessionProvider: ({
+    session,
+    children,
+  }: {
+    session: unknown;
+    children: React.ReactNode;
+  }) => (
+    <div data-testid="session-provider" data-session={JSON.stringify(session)}>
+      {children}
+    </div>
+  ),
+}));
+
+let AuthProvider: typeof import('../authProvider').AuthProvider;
+
+beforeAll(async () => {
+  AuthProvider = (await import('../authProvider')).AuthProvider;
+});
+
+const session = { user: { email: 'ada@example.com' } } as Session;
+
+describe('AuthProvider', () => {
+  it('passes the session down and renders the page inside it', () => {
+    render(
+      <AuthProvider session={session}>
+        <p>page</p>
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId('session-provider')).toHaveAttribute(
+      'data-session',
+      JSON.stringify(session),
+    );
+    expect(screen.getByText('page')).toBeInTheDocument();
+  });
+
+  it('still wraps the tree for a signed-out visitor', () => {
+    render(
+      <AuthProvider session={null}>
+        <p>signin page</p>
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId('session-provider')).toHaveAttribute(
+      'data-session',
+      'null',
+    );
+    expect(screen.getByText('signin page')).toBeInTheDocument();
+  });
+
+  it('renders without children', () => {
+    render(<AuthProvider session={null} />);
+
+    expect(screen.getByTestId('session-provider')).toBeInTheDocument();
+  });
+});

--- a/src/auth/__tests__/authSession.test.ts
+++ b/src/auth/__tests__/authSession.test.ts
@@ -111,3 +111,131 @@ describe('session callback', () => {
     expect(result.user.id).toBe(42);
   });
 });
+
+describe('credentials authorize', () => {
+  type Credentials = { email: string; password: string } | undefined;
+  type Authorized = { id: string; email: string; name: string } | null;
+
+  const authorize = async (credentials: Credentials) => {
+    const provider = auth.authOptions.providers[0] as unknown as {
+      authorize: (c: Credentials) => Promise<Authorized>;
+    };
+    return provider.authorize(credentials);
+  };
+
+  it('turns a verified user into a session subject', async () => {
+    const onCredentialsSignin = (await import('@/actions'))
+      .onCredentialsSignin as unknown as ResolvingMock;
+    onCredentialsSignin.mockResolvedValue({
+      id: 7,
+      email: 'auth@example.com',
+      name: 'Ada',
+    });
+
+    const result = await authorize({
+      email: 'auth@example.com',
+      password: 'hunter2',
+    });
+
+    // next-auth requires the id as a string, and the numeric one is put back on the
+    // token by the jwt callback below.
+    expect(result).toEqual({
+      id: '7',
+      email: 'auth@example.com',
+      name: 'Ada',
+    });
+  });
+
+  it('refuses when the credentials do not match', async () => {
+    const onCredentialsSignin = (await import('@/actions'))
+      .onCredentialsSignin as unknown as ResolvingMock;
+    onCredentialsSignin.mockResolvedValue(null);
+
+    await expect(
+      authorize({ email: 'auth@example.com', password: 'wrong' }),
+    ).resolves.toBeNull();
+  });
+
+  it('refuses when no credentials were submitted at all', async () => {
+    const onCredentialsSignin = (await import('@/actions'))
+      .onCredentialsSignin as unknown as ResolvingMock;
+
+    await expect(authorize(undefined)).resolves.toBeNull();
+    // Nothing is looked up for an empty submission.
+    expect(onCredentialsSignin).not.toHaveBeenCalled();
+  });
+});
+
+describe('jwt callback', () => {
+  type Token = { userId?: number; email?: string };
+
+  const jwt = async (args: { token: Token; user?: unknown }) => {
+    const callback = auth.authOptions.callbacks?.jwt as unknown as (
+      a: unknown,
+    ) => Promise<Token>;
+    return callback(args);
+  };
+
+  it('provisions the user on first sign-in and records the numeric id', async () => {
+    const onAfterSignin = (await import('@/actions'))
+      .onAfterSignin as unknown as ResolvingMock;
+    onAfterSignin.mockResolvedValue([{ id: 11 }]);
+
+    const token = await jwt({
+      token: {},
+      user: { email: 'auth@example.com', name: 'Ada' },
+    });
+
+    expect(onAfterSignin).toHaveBeenCalledWith({
+      email: 'auth@example.com',
+      name: 'Ada',
+    });
+    expect(token.userId).toBe(11);
+  });
+
+  it('defaults a provider that supplies no name to an empty one', async () => {
+    const onAfterSignin = (await import('@/actions'))
+      .onAfterSignin as unknown as ResolvingMock;
+    onAfterSignin.mockResolvedValue([{ id: 12 }]);
+
+    await jwt({ token: {}, user: { email: 'auth@example.com', name: null } });
+
+    expect(onAfterSignin).toHaveBeenCalledWith({
+      email: 'auth@example.com',
+      name: '',
+    });
+  });
+
+  it('recovers the id for a token issued before it was recorded', async () => {
+    const getUser = (await import('@/repository/userRepository'))
+      .getUser as unknown as ResolvingMock;
+    getUser.mockResolvedValue({ id: 13 });
+
+    // A session that predates the userId claim would otherwise never resolve to a
+    // user, and every repository call is gated on it.
+    const token = await jwt({ token: { email: 'auth@example.com' } });
+
+    expect(getUser).toHaveBeenCalledWith('auth@example.com');
+    expect(token.userId).toBe(13);
+  });
+
+  it('leaves the token alone when the address matches no user', async () => {
+    const getUser = (await import('@/repository/userRepository'))
+      .getUser as unknown as ResolvingMock;
+    getUser.mockResolvedValue(null);
+
+    const token = await jwt({ token: { email: 'gone@example.com' } });
+
+    expect(token.userId).toBeUndefined();
+  });
+
+  it('does not look anything up for a token that already knows its id', async () => {
+    const getUser = (await import('@/repository/userRepository'))
+      .getUser as unknown as ResolvingMock;
+
+    const token = await jwt({ token: { userId: 14, email: 'a@example.com' } });
+
+    expect(getUser).not.toHaveBeenCalled();
+    expect(token.userId).toBe(14);
+  });
+});

--- a/src/components/__tests__/errorToast.test.tsx
+++ b/src/components/__tests__/errorToast.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import { errorToastMessage } from '../errorToast';
+
+// This is what every failed write shows the user. The browser suite never makes a
+// write fail, so neither branch here has been exercised before.
+
+describe('errorToastMessage', () => {
+  it('includes the reason when the failure carries one', () => {
+    render(<>{errorToastMessage('Failed to save', new Error('conflict'))}</>);
+
+    expect(screen.getByText('Failed to save')).toBeInTheDocument();
+    expect(screen.getByText('conflict')).toBeInTheDocument();
+  });
+
+  it('shows the title alone when what was thrown is not an Error', () => {
+    const { container } = render(
+      <>{errorToastMessage('Failed to save', 'a bare string')}</>,
+    );
+
+    expect(screen.getByText('Failed to save')).toBeInTheDocument();
+    // Nothing is invented for a throw that carries no message.
+    expect(container).not.toHaveTextContent('a bare string');
+  });
+});

--- a/src/components/__tests__/expectedHoursFields.test.tsx
+++ b/src/components/__tests__/expectedHoursFields.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ExpectedHoursFields from '../expectedHoursFields';
+
+// Shared by the settings default, the "Special days" add form and the day-view
+// override modal. The label input appears only for the callers that pass onLabel, and
+// the empty-string fallback matters: a cleared field must report '' rather than a
+// number, or a half-typed value would be saved as hours.
+
+const noop = jest.fn();
+
+describe('ExpectedHoursFields', () => {
+  it('offers hours and minutes', () => {
+    render(
+      <ExpectedHoursFields hours={7} mins={30} onHours={noop} onMins={noop} />,
+    );
+
+    expect(screen.getByDisplayValue('7')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('30')).toBeInTheDocument();
+  });
+
+  it('omits the label field unless the caller wants one', () => {
+    const { unmount } = render(
+      <ExpectedHoursFields hours={7} mins={30} onHours={noop} onMins={noop} />,
+    );
+    expect(
+      screen.queryByPlaceholderText('Label (optional)'),
+    ).not.toBeInTheDocument();
+    unmount();
+
+    render(
+      <ExpectedHoursFields
+        hours={7}
+        mins={30}
+        onHours={noop}
+        onMins={noop}
+        onLabel={noop}
+      />,
+    );
+    expect(screen.getByPlaceholderText('Label (optional)')).toBeInTheDocument();
+  });
+
+  it('reports a label as it is typed', async () => {
+    const onLabel = jest.fn<(val: string) => void>();
+    render(
+      <ExpectedHoursFields
+        hours={7}
+        mins={30}
+        onHours={noop}
+        onMins={noop}
+        onLabel={onLabel}
+      />,
+    );
+
+    await userEvent
+      .setup()
+      .type(screen.getByPlaceholderText('Label (optional)'), 'M');
+
+    expect(onLabel).toHaveBeenCalledWith('M');
+  });
+
+  it('reports a cleared field as empty rather than as a number', async () => {
+    const onHours = jest.fn<(val: number | '') => void>();
+    render(
+      <ExpectedHoursFields
+        hours={7}
+        mins={30}
+        onHours={onHours}
+        onMins={noop}
+      />,
+    );
+
+    await userEvent.setup().clear(screen.getByDisplayValue('7'));
+
+    expect(onHours).toHaveBeenCalledWith('');
+  });
+});

--- a/src/components/__tests__/message.test.tsx
+++ b/src/components/__tests__/message.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import Message from '../message';
+
+// Every success and failure in the login flows is shown through this component, and
+// only the happy path is ever rendered by the browser suite — the error styling and
+// the optional description are reached by nothing else.
+
+describe('Message', () => {
+  it('announces itself to assistive technology', () => {
+    render(<Message type="success" title="Saved" />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Saved');
+  });
+
+  it('styles success and error differently', () => {
+    const { unmount } = render(<Message type="success" title="Saved" />);
+    expect(screen.getByRole('alert')).toHaveClass('alert-success');
+    unmount();
+
+    render(<Message type="error" title="Failed" />);
+    expect(screen.getByRole('alert')).toHaveClass('alert-error');
+  });
+
+  it('renders a description only when given one', () => {
+    const { unmount } = render(<Message type="error" title="Failed" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed');
+    unmount();
+
+    render(
+      <Message type="error" title="Failed" description="The server said no" />,
+    );
+    expect(screen.getByText('The server said no')).toBeInTheDocument();
+  });
+
+  it('lets the caller supply its own icon', () => {
+    render(
+      <Message
+        type="success"
+        title="Saved"
+        icon={<span data-testid="caller-icon" />}
+      />,
+    );
+
+    expect(screen.getByTestId('caller-icon')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/modal.test.tsx
+++ b/src/components/__tests__/modal.test.tsx
@@ -1,0 +1,104 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Modal, { closeModal, showModal } from '../modal';
+
+// Role queries pass `hidden: true` throughout: a <dialog> that has not been opened
+// is hidden, so its contents are outside the accessibility tree. These tests are
+// about the markup the modal builds, not about whether it is currently on screen.
+//
+// The secondary button is the reason this has its own test. It is deliberately
+// type="button" so that pressing it does not submit the dialog's form and dismiss
+// the modal — a confirm prompt inside a modal has to be able to say no without the
+// whole thing closing. Nothing about that is visible, so a refactor could drop the
+// attribute and only a test would notice.
+
+describe('Modal', () => {
+  const renderModal = (props: Partial<Parameters<typeof Modal>[0]> = {}) =>
+    render(
+      <Modal
+        id="a-modal"
+        confirmLabel="Save"
+        confirmAction={props.confirmAction ?? jest.fn()}
+        {...props}
+      >
+        <p>body</p>
+      </Modal>,
+    );
+
+  it('confirms through the given action', async () => {
+    // jsdom logs "Not implemented: HTMLFormElement.prototype.requestSubmit" here.
+    // That is the point rather than a problem: the confirm button is a submit button
+    // inside form method="dialog", so in a browser it both runs the action and
+    // closes the modal — which is exactly what the secondary button must not do.
+    const confirmAction = jest.fn();
+    renderModal({ confirmAction });
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: 'Save', hidden: true }));
+
+    expect(confirmAction).toHaveBeenCalled();
+  });
+
+  it('refuses to confirm while the caller says the contents are invalid', () => {
+    renderModal({ confirmDisabled: true });
+
+    expect(
+      screen.getByRole('button', { name: 'Save', hidden: true }),
+    ).toBeDisabled();
+  });
+
+  it('offers a secondary action that does not dismiss the dialog', async () => {
+    const secondaryAction = jest.fn();
+    renderModal({ secondaryLabel: 'Discard', secondaryAction });
+
+    const secondary = screen.getByRole('button', {
+      name: 'Discard',
+      hidden: true,
+    });
+    // A submit button here would close the dialog through method="dialog".
+    expect(secondary).toHaveAttribute('type', 'button');
+
+    await userEvent.setup().click(secondary);
+    expect(secondaryAction).toHaveBeenCalled();
+  });
+
+  it('omits the secondary button unless both a label and an action are given', () => {
+    const { unmount } = renderModal({ secondaryLabel: 'Discard' });
+    expect(
+      screen.queryByRole('button', { name: 'Discard', hidden: true }),
+    ).not.toBeInTheDocument();
+    unmount();
+
+    renderModal({ secondaryAction: jest.fn() });
+    expect(screen.getAllByRole('button', { hidden: true })).toHaveLength(2); // Cancel + Save only
+  });
+});
+
+describe('showModal / closeModal', () => {
+  // The helpers reach the dialog through the id-keyed global that browsers expose
+  // for elements, so a stub standing in for the element is what can be observed.
+  const stubDialog = (id: string) => {
+    const dialog = { showModal: jest.fn(), close: jest.fn() };
+    Object.assign(window, { [id]: dialog });
+    return dialog;
+  };
+
+  it('opens the dialog named by id', () => {
+    const dialog = stubDialog('open-me');
+
+    showModal('open-me');
+
+    expect(dialog.showModal).toHaveBeenCalled();
+  });
+
+  it('closes the dialog named by id', () => {
+    const dialog = stubDialog('close-me');
+
+    closeModal('close-me');
+
+    expect(dialog.close).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/modal.test.tsx
+++ b/src/components/__tests__/modal.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -78,13 +78,24 @@ describe('Modal', () => {
 });
 
 describe('showModal / closeModal', () => {
+  const stubbedIds: string[] = [];
+
   // The helpers reach the dialog through the id-keyed global that browsers expose
   // for elements, so a stub standing in for the element is what can be observed.
   const stubDialog = (id: string) => {
     const dialog = { showModal: jest.fn(), close: jest.fn() };
     Object.assign(window, { [id]: dialog });
+    stubbedIds.push(id);
     return dialog;
   };
+
+  // Taken back off the global afterwards: these names would otherwise stay set for
+  // the rest of the file.
+  afterEach(() => {
+    for (const id of stubbedIds.splice(0)) {
+      delete (window as unknown as Record<string, unknown>)[id];
+    }
+  });
 
   it('opens the dialog named by id', () => {
     const dialog = stubDialog('open-me');

--- a/src/components/__tests__/navbar.test.tsx
+++ b/src/components/__tests__/navbar.test.tsx
@@ -1,0 +1,110 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import type { Session } from 'next-auth';
+
+import type { Date_Time } from '@/util/dateFormatter';
+import type { Settings } from '@/types';
+
+// Navbar is an async server component: awaited, then the element rendered.
+//
+// Its one decision is whether the signed-in furniture appears at all, and getting it
+// wrong either strands a signed-in user without navigation or shows a signed-out
+// visitor a saldo badge. Every child is stubbed — each has its own test, and several
+// would otherwise drag server-only or next-auth modules into the graph.
+jest.mock('../menu', () => ({
+  __esModule: true,
+  default: () => <nav>menu</nav>,
+}));
+jest.mock('../saldoBadge', () => ({
+  __esModule: true,
+  default: () => <span>saldo</span>,
+}));
+jest.mock('../clock/clockBadgeIndicator', () => ({
+  __esModule: true,
+  default: () => <span>clock-indicator</span>,
+}));
+jest.mock('../quickAdd', () => ({
+  __esModule: true,
+  default: () => <span>quick-add</span>,
+}));
+jest.mock('../themeSwitcher', () => ({
+  __esModule: true,
+  default: () => <span>theme-switcher</span>,
+}));
+jest.mock('../dock', () => ({
+  __esModule: true,
+  default: () => <div>dock</div>,
+}));
+jest.mock('@/auth/authActions', () => ({
+  __esModule: true,
+  default: () => <span>auth-actions</span>,
+}));
+
+let Navbar: typeof import('../navbar').default;
+
+beforeAll(async () => {
+  Navbar = (await import('../navbar')).default;
+});
+
+const time = (s: string) => s as Date_Time;
+
+const settings: Settings = {
+  id: 1,
+  beginDate: new Date('2026-01-01'),
+  initialBalanceHours: 0,
+  initialBalanceMins: 0,
+  fromDefault: time('08:00'),
+  toDefault: time('16:00'),
+  expectedMinutesPerDay: 450,
+};
+
+const session = { user: { id: 1 } } as unknown as Session;
+
+const renderNavbar = async (props: {
+  settings: Settings | null;
+  session: Session | null;
+}) => {
+  const element = await Navbar({
+    ...props,
+    worklogs: [],
+    activeSession: null,
+    children: <main>page content</main>,
+  });
+  return render(element);
+};
+
+describe('Navbar', () => {
+  it('shows the signed-in furniture when there is a session and settings', async () => {
+    await renderNavbar({ settings, session });
+
+    for (const stub of [
+      'menu',
+      'saldo',
+      'clock-indicator',
+      'quick-add',
+      'auth-actions',
+      'dock',
+    ]) {
+      expect(screen.getByText(stub)).toBeInTheDocument();
+    }
+    expect(screen.getByText('page content')).toBeInTheDocument();
+  });
+
+  it('withholds all of it when there is no session', async () => {
+    await renderNavbar({ settings, session: null });
+
+    for (const stub of ['menu', 'saldo', 'quick-add', 'auth-actions', 'dock']) {
+      expect(screen.queryByText(stub)).not.toBeInTheDocument();
+    }
+    // The theme switcher and the page itself are for everyone.
+    expect(screen.getByText('theme-switcher')).toBeInTheDocument();
+    expect(screen.getByText('page content')).toBeInTheDocument();
+  });
+
+  it('withholds it when the user has no settings yet', async () => {
+    await renderNavbar({ settings: null, session });
+
+    expect(screen.queryByText('menu')).not.toBeInTheDocument();
+    expect(screen.queryByText('dock')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/navigation.test.tsx
+++ b/src/components/__tests__/navigation.test.tsx
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { usePathname } from 'next/navigation';
+
+import Dock from '../dock';
+import Menu from '../menu';
+import { NavBarItemArray } from '../navItems';
+
+// Dock and Menu are the same list rendered for two breakpoints, so they are tested
+// together against the shared source of truth. What matters is that every route is
+// reachable and that the current one is marked — a wrong href here strands a user on
+// a page with no way back, and nothing else in the suite checks the marking.
+jest.mock('next/navigation');
+
+const pathname = usePathname as unknown as jest.Mock<() => string>;
+
+beforeEach(() => {
+  pathname.mockReturnValue('/');
+});
+
+describe('NavBarItemArray', () => {
+  it('lists every destination exactly once', () => {
+    const hrefs = NavBarItemArray.map(([href]) => href);
+
+    expect(hrefs).toEqual([
+      '/',
+      '/worklog-items',
+      '/absence',
+      '/settings',
+      '/statistics',
+    ]);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});
+
+describe.each([
+  ['Dock', Dock, 'dock-active'],
+  ['Menu', Menu, 'border-b-2'],
+] as const)('%s', (_name, Component, activeClass) => {
+  it('links to every destination', () => {
+    render(<Component />);
+
+    for (const [href, , label] of NavBarItemArray) {
+      expect(screen.getByRole('link', { name: label })).toHaveAttribute(
+        'href',
+        href,
+      );
+    }
+  });
+
+  it('marks the route currently being viewed', () => {
+    pathname.mockReturnValue('/settings');
+    const { container } = render(<Component />);
+
+    const active = container.querySelectorAll(`.${activeClass}`);
+    expect(active).toHaveLength(1);
+    expect(active[0]).toHaveTextContent('Settings');
+  });
+
+  it('marks nothing when the route is not one of them', () => {
+    pathname.mockReturnValue('/somewhere-else');
+    const { container } = render(<Component />);
+
+    expect(container.querySelectorAll(`.${activeClass}`)).toHaveLength(0);
+  });
+});

--- a/src/components/__tests__/quickAdd.test.tsx
+++ b/src/components/__tests__/quickAdd.test.tsx
@@ -1,0 +1,72 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { Date_Time } from '@/util/dateFormatter';
+
+// QuickAdd's whole job is to open the modal, which it does through an effect rather
+// than directly — so what is asserted is that showModal was reached, and that it can
+// be reached again after a worklog is added. The modal itself is stubbed down to the
+// callback it invokes; it has its own test.
+jest.mock('../modal', () => ({ showModal: jest.fn() }));
+jest.mock('../quickAddModal', () => ({
+  __esModule: true,
+  default: ({ onSubmit }: { onSubmit: () => void }) => (
+    <button onClick={onSubmit}>stub-save</button>
+  ),
+}));
+
+type ShowModalMock = jest.Mock<(id: string) => void>;
+
+let QuickAdd: typeof import('../quickAdd').default;
+let showModal: ShowModalMock;
+
+beforeAll(async () => {
+  QuickAdd = (await import('../quickAdd')).default;
+  showModal = (await import('../modal')).showModal as unknown as ShowModalMock;
+});
+
+// Same cast helper the neighbouring worklogInputs test uses.
+const time = (s: string) => s as Date_Time;
+const fromDefault = time('08:00');
+const toDefault = time('16:00');
+
+let container: HTMLElement;
+
+beforeEach(() => {
+  showModal.mockReset();
+  container = render(
+    <QuickAdd defaults={{ fromDefault, toDefault }} />,
+  ).container;
+});
+
+// The trigger is an icon with a click handler and no accessible role of its own.
+const addIcon = () => container.querySelector('svg') as SVGElement;
+
+describe('QuickAdd', () => {
+  it('opens the quick-add modal when the icon is used', async () => {
+    await userEvent.setup().click(addIcon());
+
+    await waitFor(() =>
+      expect(showModal).toHaveBeenCalledWith('worklog-new-worklog-modal'),
+    );
+  });
+
+  it('can be opened again after a worklog is added', async () => {
+    const user = userEvent.setup();
+    await user.click(addIcon());
+    await waitFor(() => expect(showModal).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole('button', { name: 'stub-save' }));
+    await user.click(addIcon());
+
+    await waitFor(() => expect(showModal).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/components/__tests__/quickAddModal.test.tsx
+++ b/src/components/__tests__/quickAddModal.test.tsx
@@ -1,0 +1,95 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+import type { Date_Time } from '@/util/dateFormatter';
+
+// Saving is the only thing this modal does, and the browser suite only ever saves
+// successfully — so the toast a user gets when the write is refused has never run.
+// The real Modal and inputs are kept so the save button is reached the way a user
+// reaches it.
+jest.mock('@/actions', () => ({ onWorklogSubmit: jest.fn() }));
+
+type SubmitMock = jest.Mock<(data: unknown) => Promise<unknown>>;
+
+let QuickAddWorklogModal: typeof import('../quickAddModal').default;
+let ToastContext: typeof import('../toastContext').ToastContext;
+let submit: SubmitMock;
+
+beforeAll(async () => {
+  QuickAddWorklogModal = (await import('../quickAddModal')).default;
+  ToastContext = (await import('../toastContext')).ToastContext;
+  submit = (await import('@/actions')).onWorklogSubmit as unknown as SubmitMock;
+});
+
+const time = (s: string) => s as Date_Time;
+const onSubmit = jest.fn();
+const setMsg = jest.fn<(msg: unknown) => void>();
+
+/** The toast the modal asked for, rendered so its text can be read. */
+const shownToast = () => {
+  const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
+  return { type: msg.type, ...render(<>{msg.message}</>) };
+};
+
+beforeEach(() => {
+  submit.mockReset();
+  onSubmit.mockReset();
+  setMsg.mockReset();
+  render(
+    <ToastContext.Provider value={{ msg: null, setMsg }}>
+      <QuickAddWorklogModal
+        modalId="quick-add"
+        defaults={{ fromDefault: time('08:00'), toDefault: time('16:00') }}
+        onSubmit={onSubmit}
+      />
+    </ToastContext.Provider>,
+  );
+});
+
+const save = async () =>
+  userEvent
+    .setup()
+    .click(screen.getByRole('button', { name: 'Save', hidden: true }));
+
+describe('QuickAddWorklogModal', () => {
+  it('offers the defaults it was given', () => {
+    expect(screen.getByText('Add new worklog')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('08:00')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('16:00')).toBeInTheDocument();
+  });
+
+  it('saves the worklog and says so', async () => {
+    submit.mockResolvedValue(undefined);
+
+    await save();
+
+    await waitFor(() => expect(submit).toHaveBeenCalled());
+    expect(setMsg).toHaveBeenCalled();
+    const toast = shownToast();
+    expect(toast.type).toBe('success');
+    expect(screen.getByText('Worklog created')).toBeInTheDocument();
+  });
+
+  it('reports the reason when the save is refused', async () => {
+    submit.mockRejectedValue(new Error('overlaps an existing worklog'));
+
+    await save();
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(screen.getByText('Failed to create worklog')).toBeInTheDocument();
+    expect(
+      screen.getByText('overlaps an existing worklog'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/quickAddModal.test.tsx
+++ b/src/components/__tests__/quickAddModal.test.tsx
@@ -35,9 +35,17 @@ const onSubmit = jest.fn();
 const setMsg = jest.fn<(msg: unknown) => void>();
 
 /** The toast the modal asked for, rendered so its text can be read. */
+/**
+ * The toast the component asked for, rendered on its own so its text can be read.
+ *
+ * The returned queries are bound to that render, not to the document — asserting
+ * through `screen` here would also search the component's own tree, so a message that
+ * happened to appear in both would pass for the wrong reason.
+ */
 const shownToast = () => {
   const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
-  return { type: msg.type, ...render(<>{msg.message}</>) };
+  const { getByText } = render(<>{msg.message}</>);
+  return { type: msg.type, getByText };
 };
 
 beforeEach(() => {
@@ -76,7 +84,7 @@ describe('QuickAddWorklogModal', () => {
     expect(setMsg).toHaveBeenCalled();
     const toast = shownToast();
     expect(toast.type).toBe('success');
-    expect(screen.getByText('Worklog created')).toBeInTheDocument();
+    expect(toast.getByText('Worklog created')).toBeInTheDocument();
   });
 
   it('reports the reason when the save is refused', async () => {
@@ -87,9 +95,7 @@ describe('QuickAddWorklogModal', () => {
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
     const toast = shownToast();
     expect(toast.type).toBe('error');
-    expect(screen.getByText('Failed to create worklog')).toBeInTheDocument();
-    expect(
-      screen.getByText('overlaps an existing worklog'),
-    ).toBeInTheDocument();
+    expect(toast.getByText('Failed to create worklog')).toBeInTheDocument();
+    expect(toast.getByText('overlaps an existing worklog')).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/saldoBadge.test.tsx
+++ b/src/components/__tests__/saldoBadge.test.tsx
@@ -1,0 +1,89 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import type { Date_Time } from '@/util/dateFormatter';
+import type { Settings, Worklog } from '@/types';
+
+// SaldoBadge is an async server component: awaited, then the element rendered.
+//
+// The arithmetic itself belongs to the service and is tested there. What is asserted
+// here is the wiring — that the overrides are fetched and handed to the calculation,
+// and that the sign of the result decides how the badge reads, since a negative
+// balance shown as a positive one would be the most misleading bug in the app.
+jest.mock('@/repository/expectedHoursOverrideRepository', () => ({
+  getExpectedHoursOverrides: jest.fn(),
+}));
+
+type OverridesMock = jest.Mock<() => Promise<unknown[]>>;
+
+let SaldoBadge: typeof import('../saldoBadge').default;
+let getOverrides: OverridesMock;
+
+beforeAll(async () => {
+  SaldoBadge = (await import('../saldoBadge')).default;
+  getOverrides = (await import('@/repository/expectedHoursOverrideRepository'))
+    .getExpectedHoursOverrides as unknown as OverridesMock;
+});
+
+const time = (s: string) => s as Date_Time;
+
+/** Settings whose accrual window starts today, so only what is worked counts. */
+const settings = (overrides: Partial<Settings> = {}): Settings => ({
+  id: 1,
+  beginDate: new Date(),
+  initialBalanceHours: 0,
+  initialBalanceMins: 0,
+  fromDefault: time('08:00'),
+  toDefault: time('16:00'),
+  expectedMinutesPerDay: 450,
+  ...overrides,
+});
+
+beforeEach(() => {
+  getOverrides.mockReset();
+  getOverrides.mockResolvedValue([]);
+});
+
+const renderBadge = async (props: {
+  settings: Settings;
+  worklogs: Worklog[];
+}) => {
+  const element = await SaldoBadge(props);
+  return render(element);
+};
+
+describe('SaldoBadge', () => {
+  it('reads the overrides that the calculation depends on', async () => {
+    await renderBadge({ settings: settings(), worklogs: [] });
+
+    expect(getOverrides).toHaveBeenCalled();
+  });
+
+  it('shows a credit as a positive badge', async () => {
+    await renderBadge({
+      settings: settings({ initialBalanceHours: 2, initialBalanceMins: 30 }),
+      worklogs: [],
+    });
+
+    const badge = screen.getByText('2h 30min');
+    expect(badge).toHaveClass('badge-success');
+    expect(badge).toHaveClass('badge-lg');
+  });
+
+  it('shows a debt as a negative badge', async () => {
+    await renderBadge({
+      settings: settings({ initialBalanceHours: -1, initialBalanceMins: -15 }),
+      worklogs: [],
+    });
+
+    const badge = screen.getByText('-1h 15min');
+    expect(badge).toHaveClass('badge-error');
+  });
+});

--- a/src/components/__tests__/themeSwitcher.test.tsx
+++ b/src/components/__tests__/themeSwitcher.test.tsx
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ThemeSwitcher from '../themeSwitcher';
+
+// The chosen theme is remembered in localStorage, so what matters is that the switch
+// reflects what is stored and writes back the opposite. jsdom defines no matchMedia,
+// which the component already guards against — that guard is the same path a browser
+// without the media query takes.
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+const toggle = () => screen.getByRole('checkbox');
+
+describe('ThemeSwitcher', () => {
+  it('starts from the system preference when nothing is stored', () => {
+    render(<ThemeSwitcher className="icon" />);
+
+    expect(screen.getByTitle('Light/dark mode')).toBeInTheDocument();
+    expect(toggle()).not.toBeChecked();
+  });
+
+  it('reflects a stored preference', () => {
+    localStorage.setItem('saldoAlternateTheme', 'true');
+
+    render(<ThemeSwitcher className="icon" />);
+
+    expect(toggle()).toBeChecked();
+  });
+
+  it('remembers the choice when switched', async () => {
+    render(<ThemeSwitcher className="icon" />);
+
+    await userEvent.setup().click(toggle());
+
+    expect(localStorage.getItem('saldoAlternateTheme')).toBe('true');
+    expect(toggle()).toBeChecked();
+  });
+
+  it('switches back again', async () => {
+    localStorage.setItem('saldoAlternateTheme', 'true');
+    render(<ThemeSwitcher className="icon" />);
+
+    await userEvent.setup().click(toggle());
+
+    expect(localStorage.getItem('saldoAlternateTheme')).toBe('false');
+    expect(toggle()).not.toBeChecked();
+  });
+});

--- a/src/components/__tests__/themeSwitcher.test.tsx
+++ b/src/components/__tests__/themeSwitcher.test.tsx
@@ -1,16 +1,45 @@
-import { beforeEach, describe, expect, it } from '@jest/globals';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import ThemeSwitcher from '../themeSwitcher';
 
 // The chosen theme is remembered in localStorage, so what matters is that the switch
-// reflects what is stored and writes back the opposite. jsdom defines no matchMedia,
-// which the component already guards against — that guard is the same path a browser
-// without the media query takes.
+// reflects what is stored, that a stored choice beats the system preference, and that
+// switching writes the opposite back.
+//
+// matchMedia is set per test rather than left to the environment: jsdom happens not to
+// define it, so relying on that would mean a jsdom upgrade or a polyfill in
+// jest.setup.js could silently flip which branch these tests exercise while they
+// carried on passing.
+
+/** Stand in for the media query, or take it away to exercise the guard. */
+const setPrefersDark = (prefersDark: boolean | 'unsupported') => {
+  if (prefersDark === 'unsupported') {
+    delete (window as unknown as Record<string, unknown>).matchMedia;
+    return;
+  }
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: jest.fn(() => ({ matches: prefersDark })),
+  });
+};
 
 beforeEach(() => {
   localStorage.clear();
+  setPrefersDark(false);
+});
+
+afterEach(() => {
+  setPrefersDark('unsupported');
 });
 
 const toggle = () => screen.getByRole('checkbox');
@@ -23,12 +52,39 @@ describe('ThemeSwitcher', () => {
     expect(toggle()).not.toBeChecked();
   });
 
+  it('follows a dark system preference when nothing is stored', () => {
+    setPrefersDark(true);
+
+    render(<ThemeSwitcher className="icon" />);
+
+    expect(toggle()).toBeChecked();
+  });
+
+  it('works where the media query is unavailable', () => {
+    setPrefersDark('unsupported');
+
+    render(<ThemeSwitcher className="icon" />);
+
+    // The guard treats an absent matchMedia as "no dark preference" rather than
+    // throwing on every render.
+    expect(toggle()).not.toBeChecked();
+  });
+
   it('reflects a stored preference', () => {
     localStorage.setItem('saldoAlternateTheme', 'true');
 
     render(<ThemeSwitcher className="icon" />);
 
     expect(toggle()).toBeChecked();
+  });
+
+  it('lets a stored choice override the system preference', () => {
+    setPrefersDark(true);
+    localStorage.setItem('saldoAlternateTheme', 'false');
+
+    render(<ThemeSwitcher className="icon" />);
+
+    expect(toggle()).not.toBeChecked();
   });
 
   it('remembers the choice when switched', async () => {

--- a/src/components/__tests__/toast.test.tsx
+++ b/src/components/__tests__/toast.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import Toast from '../toast';
+
+// Every toast in the app goes through here, and the type is the only signal of
+// whether something went well or badly — worth pinning the whole map rather than the
+// one variant a happy-path run produces.
+
+describe('Toast', () => {
+  it.each([
+    ['info', 'alert-info'],
+    ['success', 'alert-success'],
+    ['warning', 'alert-warning'],
+    ['error', 'alert-error'],
+  ] as const)('styles a %s toast', (type, expected) => {
+    const { container } = render(
+      <Toast type={type} msg="something happened" />,
+    );
+
+    expect(screen.getByText('something happened')).toBeInTheDocument();
+    expect(container.querySelector('.alert')).toHaveClass(expected);
+  });
+
+  it('carries no type styling when none is given', () => {
+    const { container } = render(<Toast msg="plain" />);
+
+    const alert = container.querySelector('.alert');
+    expect(alert?.className.trim()).toBe('alert');
+  });
+});

--- a/src/components/__tests__/toastContext.test.tsx
+++ b/src/components/__tests__/toastContext.test.tsx
@@ -1,0 +1,66 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { act, render, screen } from '@testing-library/react';
+import { useContext } from 'react';
+
+import ToastContextWrapper, { ToastContext } from '../toastContext';
+
+// The wrapper both shows a toast and takes it away again after two seconds. The
+// dismissal is the part nothing else covers: a toast that never cleared would sit
+// over the page for the rest of the session.
+
+const Trigger = () => {
+  const { setMsg } = useContext(ToastContext);
+  return (
+    <button onClick={() => setMsg({ type: 'success', message: 'Saved' })}>
+      announce
+    </button>
+  );
+};
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('ToastContextWrapper', () => {
+  it('shows nothing until something asks it to', () => {
+    render(
+      <ToastContextWrapper>
+        <Trigger />
+      </ToastContextWrapper>,
+    );
+
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'announce' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a message and clears it again', () => {
+    render(
+      <ToastContextWrapper>
+        <Trigger />
+      </ToastContextWrapper>,
+    );
+
+    act(() => {
+      screen.getByRole('button', { name: 'announce' }).click();
+    });
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/clock/__tests__/clockBadgeIndicator.test.tsx
+++ b/src/components/clock/__tests__/clockBadgeIndicator.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import ClockBadgeIndicator from '../clockBadgeIndicator';
+
+// The indicator is how someone who wandered away from the home page knows they are
+// still clocked in. Both answers matter: showing it when there is no session would
+// be a false alarm, and hiding it during one loses hours.
+
+describe('ClockBadgeIndicator', () => {
+  it('shows nothing when the clock is not running', () => {
+    const { container } = render(<ClockBadgeIndicator activeSession={null} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('offers a way back to the clock while a session is open', () => {
+    render(
+      <ClockBadgeIndicator
+        activeSession={{ startedAt: new Date('2026-07-26T08:00:00Z') }}
+      />,
+    );
+
+    const link = screen.getByTitle('Clocked in');
+    expect(link).toHaveAttribute('href', '/');
+  });
+});

--- a/src/components/clock/__tests__/clockCard.test.tsx
+++ b/src/components/clock/__tests__/clockCard.test.tsx
@@ -1,0 +1,144 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+// The clock is the app's most-used control and it has two entirely different faces:
+// an idle button, and a running card with the elapsed time. The failure branch — the
+// toast shown when clocking in is refused — is what the browser suite cannot reach,
+// and without it a user would believe they were on the clock when they were not.
+//
+// The finalize sheet is stubbed; it has its own test. showModal is mocked because
+// jsdom implements no dialog.
+jest.mock('@/actions', () => ({ onClockIn: jest.fn() }));
+jest.mock('@/util/date', () => ({ now: jest.fn() }));
+jest.mock('../../modal', () => ({ showModal: jest.fn() }));
+jest.mock('../clockOutModal', () => ({
+  __esModule: true,
+  default: ({ onDone }: { onDone: () => void }) => (
+    <button onClick={onDone}>stub-finalize</button>
+  ),
+}));
+
+type ClockInMock = jest.Mock<(start: Date) => Promise<{ startedAt: Date }>>;
+type NowMock = jest.Mock<() => Date>;
+type ShowModalMock = jest.Mock<(id: string) => void>;
+
+let ClockCard: typeof import('../clockCard').default;
+let ToastContext: typeof import('../../toastContext').ToastContext;
+let clockIn: ClockInMock;
+let now: NowMock;
+let showModal: ShowModalMock;
+
+beforeAll(async () => {
+  ClockCard = (await import('../clockCard')).default;
+  ToastContext = (await import('../../toastContext')).ToastContext;
+  clockIn = (await import('@/actions')).onClockIn as unknown as ClockInMock;
+  now = (await import('@/util/date')).now as unknown as NowMock;
+  showModal = (await import('../../modal'))
+    .showModal as unknown as ShowModalMock;
+});
+
+const startedAt = new Date('2026-07-26T08:00:00Z');
+const setMsg = jest.fn<(msg: unknown) => void>();
+
+const shownToast = () => {
+  const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
+  return msg;
+};
+
+const renderCard = (activeSession: { startedAt: Date } | null) =>
+  render(
+    <ToastContext.Provider value={{ msg: null, setMsg }}>
+      <ClockCard activeSession={activeSession} />
+    </ToastContext.Provider>,
+  );
+
+beforeEach(() => {
+  clockIn.mockReset();
+  now.mockReset();
+  showModal.mockReset();
+  setMsg.mockReset();
+  now.mockReturnValue(new Date('2026-07-26T09:00:00Z'));
+});
+
+describe('ClockCard when idle', () => {
+  beforeEach(() => {
+    renderCard(null);
+  });
+
+  it('offers to start the clock', () => {
+    expect(
+      screen.getByRole('button', { name: /clock in/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clock out/i })).toBeNull();
+  });
+
+  it('starts the clock and switches to the running card', async () => {
+    clockIn.mockResolvedValue({ startedAt });
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: /clock in/i }));
+
+    await waitFor(() => expect(clockIn).toHaveBeenCalled());
+    expect(shownToast().type).toBe('success');
+    expect(
+      await screen.findByRole('button', { name: /clock out/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('says so when starting the clock is refused', async () => {
+    clockIn.mockRejectedValue(new Error('already clocked in'));
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: /clock in/i }));
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    expect(shownToast().type).toBe('error');
+    // Still idle: nothing should suggest a session is running.
+    expect(screen.queryByRole('button', { name: /clock out/i })).toBeNull();
+  });
+});
+
+describe('ClockCard while running', () => {
+  beforeEach(() => {
+    renderCard({ startedAt });
+  });
+
+  it('shows when the session began', () => {
+    expect(screen.getByText(/Since 08:00/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clock in/i })).toBeNull();
+  });
+
+  it('opens the finalize sheet when the clock is stopped', async () => {
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: /clock out/i }));
+
+    await waitFor(() =>
+      expect(showModal).toHaveBeenCalledWith('clock-out-modal'),
+    );
+    expect(
+      screen.getByRole('button', { name: 'stub-finalize' }),
+    ).toBeInTheDocument();
+  });
+
+  it('returns to idle once the session is finalised', async () => {
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /clock out/i }));
+    await user.click(screen.getByRole('button', { name: 'stub-finalize' }));
+
+    expect(
+      await screen.findByRole('button', { name: /clock in/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/clock/__tests__/clockOutModal.test.tsx
+++ b/src/components/clock/__tests__/clockOutModal.test.tsx
@@ -1,0 +1,168 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+// The sheet that turns a finished session into a worklog. Three things here are
+// reachable nowhere else:
+//
+//  - the midnight-crossing case, where the end time is deliberately blanked and Save
+//    held disabled rather than prefilled with a plausible-but-wrong value;
+//  - discard, which asks for confirmation first and must do nothing if refused;
+//  - both failure toasts.
+jest.mock('@/actions', () => ({
+  onClockOut: jest.fn(),
+  onClockDiscard: jest.fn(),
+}));
+
+type ActionMock = jest.Mock<(...args: unknown[]) => Promise<unknown>>;
+
+let ClockOutModal: typeof import('../clockOutModal').default;
+let ToastContext: typeof import('../../toastContext').ToastContext;
+let clockOut: ActionMock;
+let discard: ActionMock;
+
+beforeAll(async () => {
+  ClockOutModal = (await import('../clockOutModal')).default;
+  ToastContext = (await import('../../toastContext')).ToastContext;
+  const actions = await import('@/actions');
+  clockOut = actions.onClockOut as unknown as ActionMock;
+  discard = actions.onClockDiscard as unknown as ActionMock;
+});
+
+const onDone = jest.fn();
+const setMsg = jest.fn<(msg: unknown) => void>();
+
+const shownToast = () => {
+  const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
+  return { type: msg.type, ...render(<>{msg.message}</>) };
+};
+
+const renderModal = ({
+  startedAt = new Date('2026-07-26T08:00:00Z'),
+  endedAt = new Date('2026-07-26T16:00:00Z'),
+} = {}) =>
+  render(
+    <ToastContext.Provider value={{ msg: null, setMsg }}>
+      <ClockOutModal
+        modalId="clock-out"
+        startedAt={startedAt}
+        endedAt={endedAt}
+        onDone={onDone}
+      />
+    </ToastContext.Provider>,
+  );
+
+const button = (name: string) =>
+  screen.getByRole('button', { name, hidden: true });
+
+beforeEach(() => {
+  clockOut.mockReset();
+  discard.mockReset();
+  onDone.mockReset();
+  setMsg.mockReset();
+});
+
+describe('ClockOutModal', () => {
+  it('prefills the times the session actually ran', () => {
+    renderModal();
+
+    expect(screen.getByDisplayValue('08:00')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('16:00')).toBeInTheDocument();
+    expect(button('Save')).toBeEnabled();
+  });
+
+  it('saves the session as a worklog', async () => {
+    clockOut.mockResolvedValue(undefined);
+    renderModal();
+
+    await userEvent.setup().click(button('Save'));
+
+    await waitFor(() => expect(clockOut).toHaveBeenCalled());
+    expect(shownToast().type).toBe('success');
+    expect(screen.getByText('Worklog created')).toBeInTheDocument();
+  });
+
+  it('reports the reason when saving is refused', async () => {
+    clockOut.mockRejectedValue(new Error('overlaps an existing worklog'));
+    renderModal();
+
+    await userEvent.setup().click(button('Save'));
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(screen.getByText('Failed to save session')).toBeInTheDocument();
+    expect(
+      screen.getByText('overlaps an existing worklog'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('ClockOutModal when the session crossed midnight', () => {
+  const overnight = {
+    startedAt: new Date('2026-07-26T22:00:00Z'),
+    endedAt: new Date('2026-07-27T06:00:00Z'),
+  };
+
+  it('warns, blanks the end time and refuses to save', () => {
+    renderModal(overnight);
+
+    // Queried by text, not by role: the warning is a daisyUI `alert` class with no
+    // role="alert", so assistive technology is not told about it either.
+    expect(screen.getByText(/crossed midnight/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue('22:00')).toBeInTheDocument();
+    // No plausible-but-wrong end time is offered, and Save stays out of reach.
+    expect(button('Save')).toBeDisabled();
+  });
+});
+
+describe('ClockOutModal discard', () => {
+  const confirmSpy = jest.spyOn(window, 'confirm');
+
+  beforeEach(() => {
+    confirmSpy.mockReset();
+  });
+
+  it('does nothing if the confirmation is refused', async () => {
+    confirmSpy.mockReturnValue(false);
+    renderModal();
+
+    await userEvent.setup().click(button('Discard'));
+
+    expect(discard).not.toHaveBeenCalled();
+    expect(setMsg).not.toHaveBeenCalled();
+  });
+
+  it('discards the session once confirmed', async () => {
+    confirmSpy.mockReturnValue(true);
+    discard.mockResolvedValue(undefined);
+    renderModal();
+
+    await userEvent.setup().click(button('Discard'));
+
+    await waitFor(() => expect(discard).toHaveBeenCalled());
+    expect(shownToast().type).toBe('success');
+    expect(screen.getByText('Session discarded')).toBeInTheDocument();
+  });
+
+  it('says so when discarding fails', async () => {
+    confirmSpy.mockReturnValue(true);
+    discard.mockRejectedValue(new Error('no active session'));
+    renderModal();
+
+    await userEvent.setup().click(button('Discard'));
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(screen.getByText('Failed to discard session')).toBeInTheDocument();
+  });
+});

--- a/src/components/clock/__tests__/clockOutModal.test.tsx
+++ b/src/components/clock/__tests__/clockOutModal.test.tsx
@@ -1,4 +1,5 @@
 import {
+  afterAll,
   beforeAll,
   beforeEach,
   describe,
@@ -40,9 +41,17 @@ beforeAll(async () => {
 const onDone = jest.fn();
 const setMsg = jest.fn<(msg: unknown) => void>();
 
+/**
+ * The toast the component asked for, rendered on its own so its text can be read.
+ *
+ * The returned queries are bound to that render, not to the document — asserting
+ * through `screen` here would also search the component's own tree, so a message that
+ * happened to appear in both would pass for the wrong reason.
+ */
 const shownToast = () => {
   const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
-  return { type: msg.type, ...render(<>{msg.message}</>) };
+  const { getByText } = render(<>{msg.message}</>);
+  return { type: msg.type, getByText };
 };
 
 const renderModal = ({
@@ -86,8 +95,9 @@ describe('ClockOutModal', () => {
     await userEvent.setup().click(button('Save'));
 
     await waitFor(() => expect(clockOut).toHaveBeenCalled());
-    expect(shownToast().type).toBe('success');
-    expect(screen.getByText('Worklog created')).toBeInTheDocument();
+    const toast = shownToast();
+    expect(toast.type).toBe('success');
+    expect(toast.getByText('Worklog created')).toBeInTheDocument();
   });
 
   it('reports the reason when saving is refused', async () => {
@@ -99,10 +109,8 @@ describe('ClockOutModal', () => {
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
     const toast = shownToast();
     expect(toast.type).toBe('error');
-    expect(screen.getByText('Failed to save session')).toBeInTheDocument();
-    expect(
-      screen.getByText('overlaps an existing worklog'),
-    ).toBeInTheDocument();
+    expect(toast.getByText('Failed to save session')).toBeInTheDocument();
+    expect(toast.getByText('overlaps an existing worklog')).toBeInTheDocument();
   });
 });
 
@@ -125,10 +133,17 @@ describe('ClockOutModal when the session crossed midnight', () => {
 });
 
 describe('ClockOutModal discard', () => {
+  // The describe body runs during collection, so this replaces window.confirm for
+  // every test in the file — restored afterwards so a later test that does call it
+  // gets a real dialog rather than undefined.
   const confirmSpy = jest.spyOn(window, 'confirm');
 
   beforeEach(() => {
     confirmSpy.mockReset();
+  });
+
+  afterAll(() => {
+    confirmSpy.mockRestore();
   });
 
   it('does nothing if the confirmation is refused', async () => {
@@ -149,8 +164,9 @@ describe('ClockOutModal discard', () => {
     await userEvent.setup().click(button('Discard'));
 
     await waitFor(() => expect(discard).toHaveBeenCalled());
-    expect(shownToast().type).toBe('success');
-    expect(screen.getByText('Session discarded')).toBeInTheDocument();
+    const toast = shownToast();
+    expect(toast.type).toBe('success');
+    expect(toast.getByText('Session discarded')).toBeInTheDocument();
   });
 
   it('says so when discarding fails', async () => {
@@ -163,6 +179,6 @@ describe('ClockOutModal discard', () => {
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
     const toast = shownToast();
     expect(toast.type).toBe('error');
-    expect(screen.getByText('Failed to discard session')).toBeInTheDocument();
+    expect(toast.getByText('Failed to discard session')).toBeInTheDocument();
   });
 });

--- a/src/components/clock/__tests__/elapsed.test.tsx
+++ b/src/components/clock/__tests__/elapsed.test.tsx
@@ -1,0 +1,91 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { act, render, screen } from '@testing-library/react';
+
+// The running clock a user watches while clocked in. now() is mocked so the elapsed
+// figure is a fact rather than a race with the test's own wall clock.
+jest.mock('@/util/date', () => ({ now: jest.fn() }));
+
+type NowMock = jest.Mock<() => Date>;
+
+let Elapsed: typeof import('../elapsed').default;
+let now: NowMock;
+
+beforeAll(async () => {
+  Elapsed = (await import('../elapsed')).default;
+  now = (await import('@/util/date')).now as unknown as NowMock;
+});
+
+const startedAt = new Date('2026-07-26T08:00:00Z');
+const at = (isoTime: string) => new Date(`2026-07-26T${isoTime}Z`);
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  now.mockReset();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('Elapsed', () => {
+  it('shows the time since the session started', () => {
+    now.mockReturnValue(at('09:23:07'));
+
+    render(<Elapsed startedAt={startedAt} />);
+
+    expect(screen.getByText('1:23:07')).toBeInTheDocument();
+  });
+
+  it('pads minutes and seconds so the width does not jump', () => {
+    now.mockReturnValue(at('08:05:09'));
+
+    render(<Elapsed startedAt={startedAt} />);
+
+    expect(screen.getByText('0:05:09')).toBeInTheDocument();
+  });
+
+  it('keeps ticking once a second', () => {
+    now.mockReturnValue(at('08:00:00'));
+    render(<Elapsed startedAt={startedAt} />);
+    expect(screen.getByText('0:00:00')).toBeInTheDocument();
+
+    now.mockReturnValue(at('08:00:01'));
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('0:00:01')).toBeInTheDocument();
+  });
+
+  it('never counts backwards if the clock disagrees', () => {
+    // A server-side start stamped slightly ahead of the browser must not render as
+    // a negative duration.
+    now.mockReturnValue(at('07:59:30'));
+
+    render(<Elapsed startedAt={startedAt} />);
+
+    expect(screen.getByText('0:00:00')).toBeInTheDocument();
+  });
+
+  it('stops ticking once it is gone', () => {
+    now.mockReturnValue(at('08:00:00'));
+    const { unmount } = render(<Elapsed startedAt={startedAt} />);
+
+    unmount();
+    now.mockReturnValue(at('08:00:05'));
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    // The interval was cleared, so nothing tried to update an unmounted component.
+    expect(screen.queryByText('0:00:05')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/worklogItem/__tests__/worklogDeleteConfirm.test.tsx
+++ b/src/components/worklogItem/__tests__/worklogDeleteConfirm.test.tsx
@@ -34,9 +34,17 @@ const onDelete = jest.fn<(id: number) => void>();
 const setMsg = jest.fn<(msg: unknown) => void>();
 
 /** The toast the component asked for, rendered so its text can be read. */
+/**
+ * The toast the component asked for, rendered on its own so its text can be read.
+ *
+ * The returned queries are bound to that render, not to the document — asserting
+ * through `screen` here would also search the component's own tree, so a message that
+ * happened to appear in both would pass for the wrong reason.
+ */
 const shownToast = () => {
   const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
-  return { type: msg.type, ...render(<>{msg.message}</>) };
+  const { getByText } = render(<>{msg.message}</>);
+  return { type: msg.type, getByText };
 };
 
 beforeEach(() => {
@@ -76,7 +84,7 @@ describe('WorklogDeleteConfirm', () => {
     expect(remove).toHaveBeenCalledWith(7);
     const toast = shownToast();
     expect(toast.type).toBe('success');
-    expect(screen.getByText('Worklog deleted')).toBeInTheDocument();
+    expect(toast.getByText('Worklog deleted')).toBeInTheDocument();
   });
 
   it('reports the reason when the delete is refused', async () => {
@@ -87,9 +95,9 @@ describe('WorklogDeleteConfirm', () => {
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
     const toast = shownToast();
     expect(toast.type).toBe('error');
-    expect(screen.getByText('Failed to delete worklog')).toBeInTheDocument();
+    expect(toast.getByText('Failed to delete worklog')).toBeInTheDocument();
     expect(
-      screen.getByText('worklog belongs to someone else'),
+      toast.getByText('worklog belongs to someone else'),
     ).toBeInTheDocument();
     // The row must stay on screen when the delete did not happen.
     expect(onDelete).not.toHaveBeenCalled();
@@ -103,6 +111,6 @@ describe('WorklogDeleteConfirm', () => {
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
     const toast = shownToast();
     expect(toast.type).toBe('error');
-    expect(screen.getByText('Failed to delete worklog')).toBeInTheDocument();
+    expect(toast.getByText('Failed to delete worklog')).toBeInTheDocument();
   });
 });

--- a/src/components/worklogItem/__tests__/worklogDeleteConfirm.test.tsx
+++ b/src/components/worklogItem/__tests__/worklogDeleteConfirm.test.tsx
@@ -1,0 +1,108 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+// The failure branch here is the reason this test exists: the browser suite deletes
+// worklogs successfully and never makes the action reject, so the error toast — the
+// only thing telling a user their delete did not happen — has never run.
+//
+// The real ToastContext provider is used rather than a mocked useContext, so what is
+// asserted is the message a user would actually see.
+jest.mock('@/actions', () => ({ onWorklogDelete: jest.fn() }));
+
+type DeleteMock = jest.Mock<(id: number) => Promise<unknown>>;
+
+let WorklogDeleteConfirm: typeof import('../worklogDeleteConfirm').default;
+let ToastContext: typeof import('../../toastContext').ToastContext;
+let remove: DeleteMock;
+
+beforeAll(async () => {
+  WorklogDeleteConfirm = (await import('../worklogDeleteConfirm')).default;
+  ToastContext = (await import('../../toastContext')).ToastContext;
+  remove = (await import('@/actions')).onWorklogDelete as unknown as DeleteMock;
+});
+
+const onDelete = jest.fn<(id: number) => void>();
+const setMsg = jest.fn<(msg: unknown) => void>();
+
+/** The toast the component asked for, rendered so its text can be read. */
+const shownToast = () => {
+  const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
+  return { type: msg.type, ...render(<>{msg.message}</>) };
+};
+
+beforeEach(() => {
+  remove.mockReset();
+  onDelete.mockReset();
+  setMsg.mockReset();
+  render(
+    <ToastContext.Provider value={{ msg: null, setMsg }}>
+      <WorklogDeleteConfirm
+        worklogId={7}
+        confirmId="confirm-7"
+        onDelete={onDelete}
+      />
+    </ToastContext.Provider>,
+  );
+});
+
+const confirmDelete = async () =>
+  userEvent
+    .setup()
+    .click(screen.getByRole('button', { name: 'Delete', hidden: true }));
+
+describe('WorklogDeleteConfirm', () => {
+  it('asks before deleting anything', () => {
+    expect(
+      screen.getByText('Are you sure you want to delete this worklog?'),
+    ).toBeInTheDocument();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it('removes the worklog and says so', async () => {
+    remove.mockResolvedValue(undefined);
+
+    await confirmDelete();
+
+    await waitFor(() => expect(onDelete).toHaveBeenCalledWith(7));
+    expect(remove).toHaveBeenCalledWith(7);
+    const toast = shownToast();
+    expect(toast.type).toBe('success');
+    expect(screen.getByText('Worklog deleted')).toBeInTheDocument();
+  });
+
+  it('reports the reason when the delete is refused', async () => {
+    remove.mockRejectedValue(new Error('worklog belongs to someone else'));
+
+    await confirmDelete();
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(screen.getByText('Failed to delete worklog')).toBeInTheDocument();
+    expect(
+      screen.getByText('worklog belongs to someone else'),
+    ).toBeInTheDocument();
+    // The row must stay on screen when the delete did not happen.
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('omits a reason when the failure carries none', async () => {
+    remove.mockRejectedValue('a bare string');
+
+    await confirmDelete();
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(screen.getByText('Failed to delete worklog')).toBeInTheDocument();
+  });
+});

--- a/src/components/worklogItem/__tests__/worklogEditModal.test.tsx
+++ b/src/components/worklogItem/__tests__/worklogEditModal.test.tsx
@@ -41,9 +41,17 @@ const worklog: Worklog = {
 const onEdit = jest.fn();
 const setMsg = jest.fn<(msg: unknown) => void>();
 
+/**
+ * The toast the component asked for, rendered on its own so its text can be read.
+ *
+ * The returned queries are bound to that render, not to the document — asserting
+ * through `screen` here would also search the component's own tree, so a message that
+ * happened to appear in both would pass for the wrong reason.
+ */
 const shownToast = () => {
   const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
-  return { type: msg.type, ...render(<>{msg.message}</>) };
+  const { getByText } = render(<>{msg.message}</>);
+  return { type: msg.type, getByText };
 };
 
 beforeEach(() => {
@@ -82,8 +90,9 @@ describe('WorklogEditModal', () => {
     await waitFor(() =>
       expect(edit).toHaveBeenCalledWith(42, expect.anything()),
     );
-    expect(shownToast().type).toBe('success');
-    expect(screen.getByText('Worklog updated')).toBeInTheDocument();
+    const toast = shownToast();
+    expect(toast.type).toBe('success');
+    expect(toast.getByText('Worklog updated')).toBeInTheDocument();
   });
 
   it('reports the reason when the change is refused', async () => {
@@ -94,9 +103,9 @@ describe('WorklogEditModal', () => {
     await waitFor(() => expect(setMsg).toHaveBeenCalled());
     const toast = shownToast();
     expect(toast.type).toBe('error');
-    expect(screen.getByText('Failed to update worklog')).toBeInTheDocument();
+    expect(toast.getByText('Failed to update worklog')).toBeInTheDocument();
     expect(
-      screen.getByText('worklog belongs to someone else'),
+      toast.getByText('worklog belongs to someone else'),
     ).toBeInTheDocument();
   });
 });

--- a/src/components/worklogItem/__tests__/worklogEditModal.test.tsx
+++ b/src/components/worklogItem/__tests__/worklogEditModal.test.tsx
@@ -1,0 +1,102 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+
+import type { Worklog } from '@/types';
+
+// Editing is the one write that can silently corrupt existing data, so what is
+// asserted is that the row's own id goes with the change, and that a refusal is
+// reported rather than swallowed — the browser suite only ever edits successfully.
+jest.mock('@/actions', () => ({ onWorklogEdit: jest.fn() }));
+
+type EditMock = jest.Mock<(id: number, data: unknown) => Promise<unknown>>;
+
+let WorklogEditModal: typeof import('../worklogEditModal').default;
+let ToastContext: typeof import('../../toastContext').ToastContext;
+let edit: EditMock;
+
+beforeAll(async () => {
+  WorklogEditModal = (await import('../worklogEditModal')).default;
+  ToastContext = (await import('../../toastContext')).ToastContext;
+  edit = (await import('@/actions')).onWorklogEdit as unknown as EditMock;
+});
+
+const worklog: Worklog = {
+  id: 42,
+  from: new Date('2026-07-26T08:00:00Z'),
+  to: new Date('2026-07-26T16:00:00Z'),
+  subtractLunchBreak: true,
+  absence: null,
+  comment: 'worked late',
+};
+
+const onEdit = jest.fn();
+const setMsg = jest.fn<(msg: unknown) => void>();
+
+const shownToast = () => {
+  const [msg] = setMsg.mock.calls[0] as [{ type: string; message: ReactNode }];
+  return { type: msg.type, ...render(<>{msg.message}</>) };
+};
+
+beforeEach(() => {
+  edit.mockReset();
+  onEdit.mockReset();
+  setMsg.mockReset();
+  render(
+    <ToastContext.Provider value={{ msg: null, setMsg }}>
+      <WorklogEditModal
+        worklog={worklog}
+        editModalId="edit-42"
+        onEdit={onEdit}
+      />
+    </ToastContext.Provider>,
+  );
+});
+
+const confirm = async () =>
+  userEvent
+    .setup()
+    .click(screen.getByRole('button', { name: 'Edit', hidden: true }));
+
+describe('WorklogEditModal', () => {
+  it('opens on the values the worklog already has', () => {
+    expect(screen.getByDisplayValue('08:00')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('16:00')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('worked late')).toBeInTheDocument();
+  });
+
+  it('sends the change against the row it belongs to', async () => {
+    edit.mockResolvedValue(undefined);
+
+    await confirm();
+
+    // The id is what stops an edit landing on somebody else's worklog.
+    await waitFor(() =>
+      expect(edit).toHaveBeenCalledWith(42, expect.anything()),
+    );
+    expect(shownToast().type).toBe('success');
+    expect(screen.getByText('Worklog updated')).toBeInTheDocument();
+  });
+
+  it('reports the reason when the change is refused', async () => {
+    edit.mockRejectedValue(new Error('worklog belongs to someone else'));
+
+    await confirm();
+
+    await waitFor(() => expect(setMsg).toHaveBeenCalled());
+    const toast = shownToast();
+    expect(toast.type).toBe('error');
+    expect(screen.getByText('Failed to update worklog')).toBeInTheDocument();
+    expect(
+      screen.getByText('worklog belongs to someone else'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/worklogItem/__tests__/worklogItem.test.tsx
+++ b/src/components/worklogItem/__tests__/worklogItem.test.tsx
@@ -1,0 +1,117 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AbsenceReason, type Worklog } from '@/types';
+
+// The row's own logic is which controls it offers and which dialog it opens. An
+// absence has no hours to edit, so offering an edit button for one would open a form
+// over data it cannot represent — that omission is the assertion worth having.
+//
+// Both dialogs are stubbed; each has its own test. showModal is mocked because jsdom
+// implements no dialog.
+jest.mock('../../modal', () => ({ showModal: jest.fn() }));
+jest.mock('../worklogDeleteConfirm', () => ({
+  __esModule: true,
+  default: () => <div>delete-confirm</div>,
+}));
+jest.mock('../worklogEditModal', () => ({
+  __esModule: true,
+  default: () => <div>edit-modal</div>,
+}));
+
+type ShowModalMock = jest.Mock<(id: string) => void>;
+
+let WorklogItem: typeof import('../worklogItem').default;
+let showModal: ShowModalMock;
+
+beforeAll(async () => {
+  WorklogItem = (await import('../worklogItem')).default;
+  showModal = (await import('../../modal'))
+    .showModal as unknown as ShowModalMock;
+});
+
+const worklog = (overrides: Partial<Worklog> = {}): Worklog => ({
+  id: 42,
+  from: new Date('2026-07-26T08:00:00Z'),
+  to: new Date('2026-07-26T16:00:00Z'),
+  subtractLunchBreak: false,
+  absence: null,
+  comment: null,
+  ...overrides,
+});
+
+const renderItem = (overrides: Partial<Worklog> = {}, ignored?: boolean) =>
+  render(
+    <WorklogItem
+      worklog={worklog(overrides)}
+      onDelete={jest.fn()}
+      onEdit={jest.fn()}
+      ignored={ignored}
+    />,
+  );
+
+beforeEach(() => {
+  showModal.mockReset();
+});
+
+describe('WorklogItem', () => {
+  it('offers edit and delete for a worked entry', () => {
+    renderItem();
+
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('offers no edit for an absence, which has no hours to change', () => {
+    renderItem({ absence: AbsenceReason.holiday });
+
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('shows a comment when there is one', () => {
+    const { unmount } = renderItem();
+    expect(screen.queryByText('worked late')).not.toBeInTheDocument();
+    unmount();
+
+    renderItem({ comment: 'worked late' });
+    expect(screen.getByText('worked late')).toBeInTheDocument();
+  });
+
+  it('opens the delete confirmation for its own row', async () => {
+    renderItem();
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: 'Delete' }));
+
+    // The id carries the worklog id, so one row's dialog cannot delete another's.
+    await waitFor(() =>
+      expect(showModal).toHaveBeenCalledWith('worklog-delete-confirm-42'),
+    );
+  });
+
+  it('opens the edit dialog for its own row', async () => {
+    renderItem();
+
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Edit' }));
+
+    await waitFor(() =>
+      expect(showModal).toHaveBeenCalledWith('worklog-edit-modal-42'),
+    );
+  });
+
+  it('dims a row that does not count towards the balance', () => {
+    const { container } = renderItem({}, true);
+
+    expect(container.querySelector('.bg-base-100')).not.toBeNull();
+  });
+});

--- a/src/components/worklogItem/__tests__/worklogTitle.test.tsx
+++ b/src/components/worklogItem/__tests__/worklogTitle.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import { AbsenceReason, type Worklog } from '@/types';
+
+import WorklogTitle from '../worklogTitle';
+
+// The title is the whole of what a row says about itself, and it says three different
+// things: an absence names its reason, a worked entry shows its hours, and a lunch
+// break is marked with an icon and nothing else. The lunch marker is the one a user
+// would miss — it is the difference between 7.5 and 8 hours counted.
+
+const worklog = (overrides: Partial<Worklog> = {}): Worklog => ({
+  id: 1,
+  from: new Date('2026-07-26T08:00:00Z'),
+  to: new Date('2026-07-26T16:00:00Z'),
+  subtractLunchBreak: false,
+  absence: null,
+  comment: null,
+  ...overrides,
+});
+
+describe('WorklogTitle', () => {
+  it('shows the hours worked', () => {
+    const { container } = render(<WorklogTitle worklog={worklog()} />);
+
+    expect(screen.getByText('08:00 - 16:00')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('marks an entry whose lunch break was deducted', () => {
+    const { container } = render(
+      <WorklogTitle worklog={worklog({ subtractLunchBreak: true })} />,
+    );
+
+    expect(screen.getByText('08:00 - 16:00')).toBeInTheDocument();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('names the reason instead of hours for an absence', () => {
+    render(
+      <WorklogTitle worklog={worklog({ absence: AbsenceReason.sick_leave })} />,
+    );
+
+    expect(screen.queryByText('08:00 - 16:00')).not.toBeInTheDocument();
+    // The reason wording comes from the service that maps the enum to words.
+    expect(screen.getByRole('heading')).toHaveTextContent(/sick/i);
+  });
+});


### PR DESCRIPTION
## Why

`src/app` sat at ~40% and `src/components` at ~61%, but most of that gap was **not** untested code — it was two instrumentation granularities being merged:

```
  src/app + src/components — 70 files
    jest tracks   1009 lines   (istanbul: every statement)
    e2e tracks     347 lines   (V8 on bundled code: function boundaries only)

    38 files  exercised by e2e, scoring 0/N in jest
    15 files  genuinely dark in both layers
```

Codecov took the denominator from Jest and the numerator from e2e, so `expectedHoursOverrides.tsx` covered 10/10 of everything e2e can see and still read ~20%. **e2e tests cannot move those numbers** — V8 will never mark the other 38 lines no matter how many browser journeys drive the component.

So this targets the code that is genuinely untested, not the number:

- **Tier 1 — dark in both layers (126 lines):** the `(login)` tree. Three forms, four pages, the sign-in error message, the field-error handler.
- **Tier 2 — real unexercised branches:** six components whose *e2e-visible* coverage was itself poor (`message.tsx` 1/6, `errorToast.tsx` 1/3) because the browser suite only ever takes the happy path.

Deliberately **not** included: Jest tests for the 16 e2e-covered components where the percentage is simply mis-measured. That would be writing tests to move a metric.

## Result

| | before | after |
|---|---|---|
| Union total | 64.0% | **75.2%** |
| `src/app/(login)` | 7.05% | **92.9%** |
| `src/app` | ~40% | 61.6% |
| `src/components` | 61% | 68.2% |
| Files dark in every layer | 16 | **0** |

Jest-only 51.1% → 63.5%; 359 → 419 tests.

## Worth a reviewer's attention

- **The reset-token guard** (`reset-password/page.tsx`) decides whether a token from a URL may reach the form at all. All three answers are now driven: no token, a repeated token parameter, one matching no stored hash. `Page2` is left real on the accepted path, so that test proves the form is reachable and carries the token rather than proving a stub was called.
- **`modal.tsx`'s secondary button** is deliberately `type="button"` so it doesn't submit the dialog form and dismiss the modal. Nothing about that is visible; a refactor could drop it and only a test would notice.
- **`worklogDeleteConfirm`'s catch branch** is the only thing that tells a user their delete didn't happen.
- **An incomplete shared mock is fixed:** `__mocks__/next/navigation.ts` had no `refresh()`, which `useTransitionWrapper` calls after every mutation. `absence.test.tsx` has been producing an unhandled rejection nothing asserted on.
- **`*.d.ts` excluded from `collectCoverageFrom`** — no runtime code, so its lines only depressed the figure.

## Choices a reviewer might push back on

- No spec changes and no `@scenario` annotations. The auth scenarios are action-level and already covered by `authActions.test.ts`; a test asserting "the field error is displayed" does not assert "no user is created", so annotating these would over-claim. Component tests here carry no annotations by convention.
- `credentialsSignin.tsx` and `oauthSignin.tsx` are stubbed in the sign-in page test, leaving `signin/` at 66%. Neither was dark — the Playwright auth setup drives the credentials form every run — so they fell in the out-of-scope group.
- The `e instanceof Error` fallback is covered once, in the sign-up form, rather than three times over identical copy-pasted code. Remaining branch gaps are defensive `?? {}` defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)