### PR TITLE
docs: give contributors real documentation under docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,163 +1,149 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) working in this repository.
+
+The prose lives in [`docs/`](docs/) — [architecture](docs/architecture.md),
+[testing](docs/testing.md), [contributing](docs/CONTRIBUTING.md),
+[getting started](docs/getting-started.md). Read the relevant page before a
+non-trivial change. What follows is the short list of things that produce **wrong
+code** if you do not know them.
 
 ## What this is
 
-Saldo is a work-hours tracking app. Its core domain concept is the **saldo** — the running balance between hours actually worked and hours expected (`EXPECTED_HOURS_PER_DAY = 7.5`). The balance is computed from a user's `beginDate` forward, skipping non-working days (weekends + public holidays via `date-holidays`), with a configurable initial balance. See `src/services/index.tsx` for the calculation logic.
+Saldo tracks work hours. Its domain concept is the **saldo** — the running balance
+between hours worked and hours expected (`EXPECTED_HOURS_PER_DAY = 7.5`), computed
+from a user's begin date forward, skipping weekends and public holidays. The
+calculation is in `src/services/index.tsx`.
 
-## Stack
+Next.js 16 (App Router) · React 19 · TypeScript (strict) · Prisma 7 + PostgreSQL ·
+NextAuth 4 · Tailwind 4 + daisyUI · Zod + react-hook-form · Chart.js · dayjs · Sentry.
 
-Next.js 16 (App Router) · React 19 · TypeScript (strict) · Prisma 7 + PostgreSQL (via `pg` adapter) · NextAuth 4 · Tailwind 4 + daisyUI · Zod + react-hook-form · Chart.js · dayjs · Sentry.
+## Rules
+
+**Layers.** `page/component → action → repository → Prisma`, with `services` pure and
+off to the side. Do not skip a layer.
+
+- `src/app/` — pages, async server components by default; they call repositories directly.
+- `src/actions/index.ts` — the single `'use server'` module. Every mutation goes here:
+  validate with a Zod schema, then delegate. The only place a client component may
+  trigger a write.
+- `src/repository/` — `server-only`. Every function calls `getUserFromSession()` first
+  and enforces per-user ownership. Prisma types **do not leak past this boundary**;
+  map to the `camelCase` types in `src/types/`.
+- `src/services/` — pure. No DB, no session.
+
+**Return user-facing errors from actions; do not throw them.** A production build
+replaces a thrown error's message with an opaque digest, so a toast that reads fine in
+`next dev` is empty in CI and in production. `onAbsenceSubmit` is the worked example.
+
+**All date maths is UTC.** Use the helpers in `src/util/date.ts` (which sets
+`dayjs.tz.setDefault('UTC')`), never `dayjs` directly.
+
+**Use the branded date types** — `Date_ISODay`, `Date_Time`, `Date_YearAndMonth` from
+`src/util/dateFormatter.ts` — and construct them with the `assertIs*` guards in
+`src/util/assertionFunctions.ts` rather than casting.
+
+**The Prisma client is generated to `src/generated/prisma`**, not `node_modules`.
+Import from `@/generated/prisma/client`. Run `prisma generate` after schema changes.
+
+**Path alias `@/*` → `src/*`.** Tests live in `__tests__/` beside the code.
 
 ## Commands
 
 ```bash
-npm run dev          # next dev (port 3000)
-npm run build        # next build (outputs to build/ unless on Vercel)
-npm test             # jest in WATCH mode — does not exit
-npm run test:ci      # jest --ci --coverage — use this for a single run
-npm run test:e2e     # playwright (time-clock e2e; see one-time setup below)
-npm run test:e2e:ui  # playwright --ui (watch/debug)
-npm run test:e2e:coverage   # same suite, collecting V8 coverage (slower; opt-in)
-npm run coverage:e2e:report # convert the collected profiles into lcov
-npm run lint         # eslint (max-warnings=0) + prettier --check
-npm run lint:fix     # eslint --fix + prettier --write
+npm run dev          # port 3000
+npm run test:ci      # Jest ONCE — `npm test` is watch mode and will not exit
+npx jest <path>      # a single file; add -t "name" to filter
+npm run test:e2e     # Playwright (one-time setup — see docs/testing.md)
+npm run lint         # eslint --max-warnings=0 + prettier --check
+npm run spec:coverage # regenerate openspec/COVERAGE.md
 ```
 
-- **Two test layers.** Jest (`src/**/__tests__`, jsdom) for unit/logic and server-layer code with Prisma/session mocked; Playwright (`e2e/`) for browser end-to-end. `test:ci` runs Jest only — `e2e/` is excluded from it.
-- **Run a single test:** `npx jest src/services/__tests__/someFile.test.ts` (add `-t "name"` to filter by test name). `npm test` defaults to watch mode and will not terminate.
-- **Running e2e** needs a one-time setup, then `npm run test:e2e`:
-  ```bash
-  docker compose up -d db
-  docker compose exec -T db psql -U postgres -c "CREATE DATABASE saldo_test"  # once
-  cp .env.e2e.example .env.e2e                                                # once
-  ```
-  It boots the app on port **3100** against `saldo_test` (never the dev DB), applies migrations, and seeds a test user. See `e2e/README.md` for the harness and scenario→spec traceability.
-- Husky pre-commit runs `lint-staged`; commit-msg enforces Conventional Commits (commitlint). Keep commits conventional or they will be rejected.
+The pre-commit hook runs Prettier over staged JS/TS only — **it does not run ESLint**
+(`.lintstagedrc.js` declares the same glob twice). Run `npm run lint` yourself.
+Commit messages must be Conventional Commits; commitlint rejects anything else.
 
-### Coverage reporting
+## Tests and specs
 
-Both layers report line coverage to Codecov, each under its own flag — Jest as `unit`,
-the Playwright suite as `e2e`. They cover near-complementary halves of the codebase
-(Jest holds `services`/`repository`/`util`; Playwright drives every `page.tsx` and
-component), so only the pair describes the whole.
+Every scenario in `openspec/specs/` needs a test or an exemption, and every requirement
+needs a Playwright test or a categorised one. Declare coverage above the test:
 
-```bash
-npm run test:e2e:coverage    # E2E_COVERAGE=1: source maps, server profiler, browser collector
-npm run coverage:e2e:report  # writes coverage-e2e/{server,browser}/lcov.info
+```ts
+// @scenario time-clock/Clock in when idle
 ```
 
-- **Opt-in.** One switch (`E2E_COVERAGE`) drives the build's source maps,
-  `NODE_V8_COVERAGE` on the app server, and the `page.coverage` collector in
-  `e2e/fixtures.ts`. A plain `npm run test:e2e` is unaffected and writes nothing.
-- **Every spec takes `test` from `e2e/fixtures.ts`,** not `@playwright/test` — that is
-  what starts the browser profiler. A file that imports the runner directly is not
-  collected and nothing about it looks wrong, so a Jest test fails the build on one.
-- **One report per runtime, both uploaded under `e2e`.** They are not merged locally:
-  the converter resolves both runtimes to the same source path but does not union their
-  execution counts, so the server's zero would mask a browser hit for every file both
-  touch. Codecov unions uploads within a flag.
-- **The report step fails loudly** when a runtime contributed nothing, when no project
-  source survives filtering, or when a path does not resolve on disk. Silent-empty is
-  this mechanism's characteristic failure: the coverage service would carry the previous
-  report forward and the number would stay plausible while ceasing to be true.
-- **Execution is not assertion.** A file is green here because it ran, not because
-  anything checked what it did — `navbar.tsx` renders on every page. Whether a scenario
-  is actually asserted is what spec-to-test traceability below answers.
+Claim a scenario only if the test asserts that scenario's THEN. Regenerate and commit
+`openspec/COVERAGE.md` when annotations or specs change — CI fails on a stale map.
+Every e2e spec takes `test` from `e2e/fixtures.ts`, never `@playwright/test`.
+Full rules: [docs/testing.md](docs/testing.md).
 
-### Spec-to-test traceability
+## After every change: check the docs
 
-Two rules, both enforced by CI from the same annotations:
+Documentation here is hand-written and nothing detects its drift, so **check it as
+part of the change, not afterwards**. Ask what the change altered, and update the file
+that describes it in the same commit series:
 
-1. Every **scenario** in `openspec/specs/` must be covered by a test or explicitly exempt.
-2. Every **requirement** must have at least one of its scenarios covered by a **Playwright** test, or carry a categorised end-to-end exemption.
+| If the change touched…                              | Check                                              |
+| --------------------------------------------------- | -------------------------------------------------- |
+| A command, script, or env var                        | `docs/getting-started.md`, and this file's Commands |
+| A layer boundary, convention, or the Prisma schema   | `docs/architecture.md`, and this file's Rules       |
+| How tests run, coverage, or the traceability rules   | `docs/testing.md`, `e2e/README.md`                  |
+| The commit, PR, or OpenSpec workflow                 | `docs/CONTRIBUTING.md`                              |
+| Features, screenshots, or the stack                  | `README.md`                                         |
+| Anything user-visible                                | Regenerate the user guide (below)                   |
+| A capability's behaviour                             | `openspec/specs/` via the sync step                 |
 
-```bash
-npm run spec:coverage      # regenerate openspec/COVERAGE.md (commit the result)
-npm run spec:coverage:ci   # what CI runs: --check --strict, writes nothing
-```
+Say explicitly which docs you checked and why nothing needed changing, when nothing
+did. Silence reads as "not considered".
 
-- **Declare coverage next to the test**, in either layer (Jest or Playwright):
-  ```ts
-  // @scenario time-clock/Clock in when idle
-  it('records the session start', () => { ... })
-  ```
-  Stack the comments to claim several scenarios; on a `describe` / `test.describe` the claim applies to every test inside. Many-to-many is fine — one test may cover several scenarios, and several tests may jointly cover one.
-- **A test may claim a scenario only if it asserts that scenario's THEN.** No tool can catch an over-claim; this is a review check. If a scenario's THEN spans layers (e.g. "throws a validation error **and** nothing is written"), a schema-level test alone does not cover it — assert the persistence half at the action level too, or let two tests jointly cover it.
-- **Regenerate and commit `openspec/COVERAGE.md`** whenever annotations or specs change; CI fails on a stale map. Renaming a scenario deliberately breaks the annotations citing it — that is the signal to re-read those tests.
-- **Cannot be automated?** Add an entry under `scenarios` in `scripts/spec-coverage.exemptions.json` with a written reason (a `<capability>/*` wildcard is allowed). Exemptions are self-policing: one naming an unknown scenario fails, and so does one for a scenario a test already covers.
-- **The end-to-end rule is per requirement, not per scenario** — one browser test of the journey is enough, so the rules beneath it don't each need one. The layer is read from the test's path (`e2e/**`); there is no extra syntax. A requirement whose scenarios are all scenario-exempt needs no end-to-end decision.
-- **No Playwright test for a requirement?** Say why, under `requirementsWithoutE2e`, with one of four categories:
-
-  | Category | Means |
-  | --- | --- |
-  | `no-ui` | The requirement has no user-visible surface at all. |
-  | `unit-appropriate` | Observable, but pinned more precisely at a lower layer. |
-  | `external-dependency` | Needs a third party the test environment cannot drive. |
-  | `harness-cost` | Declined deliberately: the setup outweighs the confidence gained. |
-
-  `harness-cost` additionally requires `coveredAt`, naming an existing test file that does cover it — it is the one category asserting a judgement rather than a fact, so the claim is made checkable. These exemptions rot the same way scenario ones do: an unknown requirement fails, and so does one that has since gained a Playwright test.
-
-## Local setup (Docker Compose)
-
-```bash
-docker compose up -d db   # Postgres on localhost:3006
-./run-migrations.sh       # prisma migrate deploy against localhost:3006
-docker compose up         # app on localhost:3000
-```
-
-`POSTGRES_PRISMA_URL` is the connection string used everywhere. `NEXTAUTH_URL`/`NEXTAUTH_SECRET` and OAuth creds (`GOOGLE_*`, `GITHUB_*`) are required outside local dev. See `docs/getting-started.md`.
-
-## Architecture — layered, server-first
-
-Data flows `page/component → action → repository → Prisma`, with `services` holding pure business logic. Respect these boundaries:
-
-- **`src/app/`** — App Router pages (all `async` server components by default) and the NextAuth route handler. Route groups: `(calendar)` (home), `(login)` (signin/signup/forgot/reset). Pages call repository functions directly to read data.
-- **`src/actions/index.ts`** — the single `'use server'` module. All mutations (worklog CRUD, settings, signup, password reset) go through here. Actions validate input with Zod schemas, then delegate to repositories. This is the only place client components are allowed to trigger writes.
-- **`src/repository/`** — `server-only` data access. Every function calls `getUserFromSession()` first and **enforces per-user ownership** (e.g. `updateWorklog`/`deleteWorklog` throw on `user_id` mismatch). DB calls are wrapped in `Sentry.startSpan`. Mapper functions (e.g. `toWorklog`) translate Prisma's `snake_case` rows into the `camelCase` domain types in `src/types`.
-- **`src/services/index.tsx`** — pure, side-effect-free business logic (saldo calculation, worklog summing/sorting, minutes↔badge formatting). No DB or session access here.
-- **`src/auth/`** — NextAuth config (`authSession.ts`). JWT session strategy; Credentials + Google + GitHub providers. On first sign-in, `onAfterSignin` upserts the user and seeds default `Settings`. The user's numeric DB id is stashed in the JWT (`token.userId`) and surfaced as `session.user.id`. Use `getUserFromSession()` as the auth gate in server code.
-
-### Key conventions
-
-- **Prisma client is generated to `src/generated/prisma`** (not `node_modules`). Import from `@/generated/prisma/client`. Run `prisma generate` after schema changes (also runs on `postinstall`).
-- **Branded date types.** `src/util/dateFormatter.ts` defines opaque string types (`Date_ISODay`, `Date_Time`, `Date_YearAndMonth`, …) and `src/util/assertionFunctions.ts` provides `assertIs*` guards to construct/validate them. Prefer these over raw strings when passing formatted dates around — they catch format mismatches at the type level.
-- **All date math is UTC.** `src/util/date.ts` sets `dayjs.tz.setDefault('UTC')`. Use the helpers there (`add`, `startOfDay`, `isNonWorkingDay`, etc.) rather than calling dayjs directly.
-- **Domain types** (`Worklog`, `Settings`, `User`, `AbsenceReason`, form-data shapes) live in `src/types/index.ts`. The Prisma models are mapped into these at the repository boundary — don't leak Prisma types past it.
-- **Path alias:** `@/*` → `src/*` (configured in both tsconfig and jest).
-- Tests live in `__tests__/` dirs next to the code (jsdom environment, Testing Library). `__mocks__/next/navigation.ts` mocks router for component tests.
+The user guide (`docs/user-guide/`) is generated — do not hand-edit its pages. Run
+`/generate-user-guides` (`--check` for a staleness report).
 
 ## OpenSpec workflow (`/opsx:*`)
 
-The end-to-end pipeline is **explore → propose → apply → archive**, one PR per change. The `/opsx:*` commands themselves **do not touch git** — I drive all git actions (branch, commit, push, PR) as separate steps at the points below. `openspec/` is in `.prettierignore` and lint-staged only runs on `*.{js,jsx,ts,tsx}`, so spec markdown is never reformatted by the pre-commit hook. All commits use the enforced Conventional Commit types (commitlint rejects otherwise): `feat(...)`, `fix(...)`, `docs(...)`, `refactor(...)`, `test(...)`, scoped to the area touched.
+**explore → propose → apply → archive**, one PR per change. The `/opsx:*` commands do
+not touch git; drive git yourself at the points below. `openspec/` is in
+`.prettierignore` and lint-staged only runs on `*.{js,jsx,ts,tsx}`, so spec markdown is
+never reformatted by the hook.
 
-### `/opsx:explore` — think, don't build
-Planning and investigation only. No git actions.
+**`/opsx:explore`** — planning and investigation only. No git actions.
 
-### `/opsx:propose` — branch off fresh develop, then open the PR
-- **Branch first:** `git fetch origin develop`, then create the change branch from `origin/develop` (untracked proposal files carry across the switch).
-- Generate the artifacts (proposal/design/specs/tasks).
-- Once planning is complete, propose: **commit the proposal** (`docs(openspec): propose <change-name>`), **push**, and **open a new PR** against `develop`. The PR exists from the proposal stage; apply commits land on it.
+**`/opsx:propose`** — `git fetch origin develop`, branch from `origin/develop`
+(untracked proposal files carry across the switch), generate the artifacts, then commit
+`docs(openspec): propose <change-name>`, push, and open a PR against `develop`. The PR
+exists from the proposal stage; apply commits land on it.
 
-### `/opsx:apply` — commit per task, sync the specs, verify, then push
-- Review the diff; never blind-commit.
-- **Commit once per top-level task group** in `tasks.md` (each commit carries that group's code plus its `tasks.md` checkbox updates). Intermediate commits need not independently build — only the branch tip must be green (tests + lint + typecheck).
-- **Finish with the spec sync**, in its own commit:
-  ```
-  docs(openspec): sync <capability> spec(s) for <change-name>
-  ```
-  Run `/opsx:sync`, then `npm run spec:coverage`, and commit the synced specs together with the regenerated `openspec/COVERAGE.md`. This has to happen here, not at archive: `scripts/spec-coverage.mjs` reads only `openspec/specs/`, so a change that adds scenarios leaves every annotation citing them unresolvable — and CI's `spec:coverage:ci` step red — until the delta reaches the canonical specs. Archiving is supposed to wait for green CI, so the sync cannot wait for archiving.
-  - The sync applies the delta's requirements. **Open Questions the change resolves are yours to remove by hand** — the delta format has no operation for them, and a resolved question left in place is a false statement in the canonical spec. Check every capability the change touches, not only those with a delta.
-- When apply is done, **pause and ask the user to manually verify** the implementation and for any change suggestions. **Push only once the user gives the OK.**
-- **Do not archive in this step.**
+**`/opsx:apply`** — review the diff; never blind-commit. **One commit per top-level task
+group** in `tasks.md`, each carrying that group's code plus its checkbox updates. Only
+the branch tip must be green.
 
-### `/opsx:archive` — archive while the PR is open
-- **Timing:** run it while the **PR is still open**, once everything is **reconciled and mergeable** (CI green, review addressed) — it does not wait for formal approval.
-- The specs were already synced at the end of apply. If the change was edited after that, **re-run the sync first** so canonical specs do not drift from the change being archived; otherwise the prompt's "Sync now" is a no-op.
-- **One dedicated commit** for the folder move:
-  ```
-  docs(openspec): archive <change-name>
-  ```
-  Commit it **verbatim** — generated output (the `mv` to `changes/archive/YYYY-MM-DD-<name>`). Keep it **isolated from implementation commits** so the move renders as a rename and reverts as a unit.
-- After the archive commit, **push**.
+Finish with the spec sync in its own commit:
+
+```
+docs(openspec): sync <capability> spec(s) for <change-name>
+```
+
+Run `/opsx:sync`, then `npm run spec:coverage`, and commit the synced specs with the
+regenerated `COVERAGE.md`. This must happen here, not at archive: `spec-coverage.mjs`
+reads only `openspec/specs/`, so a change adding scenarios leaves every annotation
+citing them unresolvable — and CI red — until the delta reaches the canonical specs.
+
+The sync applies requirements only. **Open Questions the change resolves are yours to
+remove by hand** — the delta format has no operation for them, and a resolved question
+left in place is a false statement in the canonical spec. Check every capability the
+change touches, not only those with a delta.
+
+When apply is done, **pause and ask the user to verify** the implementation. **Push
+only once they give the OK.** Do not archive in this step.
+
+**`/opsx:archive`** — run it while the PR is **still open**, once everything is
+reconciled and mergeable (CI green, review addressed); it does not wait for formal
+approval. If the change was edited after the sync, re-run the sync first. Then **one
+dedicated commit** for the folder move, verbatim generated output, isolated from
+implementation commits so it renders as a rename and reverts as a unit:
+
+```
+docs(openspec): archive <change-name>
+```
+
+Push after the archive commit.

--- a/README.md
+++ b/README.md
@@ -76,53 +76,18 @@ Running without Docker, the full environment variable list, and the non-local au
 | **Testing**   | Jest + Testing Library · Playwright · Codecov                          |
 | **Ops**       | Sentry · Vercel                                                        |
 
-## Development
-
-| Command                 | What it does                                 |
-| ----------------------- | -------------------------------------------- |
-| `npm run dev`           | Dev server on port 3000                      |
-| `npm run build`         | Production build                             |
-| `npm run test:ci`       | Jest, single run with coverage               |
-| `npm test`              | Jest in **watch mode** — does not exit       |
-| `npm run test:e2e`      | Playwright end-to-end suite                  |
-| `npm run lint`          | ESLint (`--max-warnings=0`) + Prettier check |
-| `npm run lint:fix`      | ESLint `--fix` + Prettier `--write`          |
-| `npm run spec:coverage` | Regenerate `openspec/COVERAGE.md`            |
-
-Run a single Jest test with `npx jest src/services/__tests__/someFile.test.ts` (add `-t "name"` to filter). The e2e suite needs a one-time database and `.env.e2e` setup — see **[`e2e/README.md`](e2e/README.md)**.
-
-Commits go through Husky: `lint-staged` on pre-commit, and commitlint enforcing [Conventional Commits](https://www.conventionalcommits.org/) on the message.
-
-### Architecture
-
-Data flows `page/component → action → repository → Prisma`, with pure business logic kept to the side:
-
-- **`src/app/`** — App Router pages, async server components by default.
-- **`src/actions/`** — the single `'use server'` module; every mutation validates with Zod, then delegates.
-- **`src/repository/`** — `server-only` data access that enforces per-user ownership on every call.
-- **`src/services/`** — pure, side-effect-free domain logic: the saldo calculation itself.
-
-The conventions that are easy to trip over — branded date types, UTC-only date math, the generated Prisma client location — are documented in **[`CLAUDE.md`](CLAUDE.md)**.
-
-## Testing & quality
-
-Two test layers cover near-complementary halves of the codebase and report to Codecov under separate flags: Jest (`unit`) holds the services, repository, and util layers; Playwright (`e2e`) drives every page and component. Only the pair describes the whole, which is why both carry forward.
-
-Beyond coverage, CI enforces **spec-to-test traceability**: every scenario in `openspec/specs/` must be claimed by a test or explicitly exempt, and every requirement needs at least one Playwright test or a categorised exemption. Tests declare what they cover inline:
-
-```ts
-// @scenario time-clock/Clock in when idle
-it('records the session start', () => { ... })
-```
-
-The generated map lives in **[`openspec/COVERAGE.md`](openspec/COVERAGE.md)**.
-
 ## Documentation
 
-- **[User guide](https://oskkos.github.io/saldo/)** — task-oriented guide for people using Saldo, generated from the specs.
-- **[Getting started](docs/getting-started.md)** — full local setup and environment variables.
-- **[`openspec/`](openspec/)** — capability specs and the change workflow.
-- **[`CLAUDE.md`](CLAUDE.md)** — architecture, conventions, and the contribution workflow in detail.
+Everything below lives in **[`docs/`](docs/)**.
+
+|                                                   |                                                                                                           |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **[Getting started](docs/getting-started.md)**    | Local setup in full — prerequisites, Docker and non-Docker paths, environment variables, troubleshooting. |
+| **[Architecture](docs/architecture.md)**          | Layer boundaries, the `src/` map, the data model, and the conventions that bite.                          |
+| **[Testing](docs/testing.md)**                    | The two test layers, coverage, and spec-to-test traceability.                                             |
+| **[Contributing](docs/CONTRIBUTING.md)**          | Commit conventions, git hooks, and the OpenSpec workflow.                                                 |
+| **[User guide](https://oskkos.github.io/saldo/)** | For people _using_ Saldo. Generated from the specs — see [`docs/user-guide/`](docs/user-guide/README.md). |
+| **[`openspec/`](openspec/)**                      | Capability specs: the behaviour the code is meant to have.                                                |
 
 ## License
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,136 @@
+# Contributing
+
+Start with [Getting started](getting-started.md) for a working local setup, and
+[Architecture](architecture.md) for the layer boundaries — most review comments on
+this repository are about a layer being skipped.
+
+## Before you open a pull request
+
+```bash
+npm run lint            # ESLint (--max-warnings=0) + Prettier check
+npm run test:ci         # Jest
+npm run test:e2e        # Playwright, if you touched anything user-visible
+npm run spec:coverage   # regenerate openspec/COVERAGE.md if specs or annotations moved
+npm run build           # only build failures are worth catching this way
+```
+
+CI runs lint, Prettier, `spec:coverage:ci`, and Jest on every push and pull request.
+The branch tip has to be green; intermediate commits do not.
+
+## Branches and commits
+
+Branch off a freshly fetched `develop`, and open the pull request against `develop`.
+
+```bash
+git fetch origin develop
+git checkout -b feat/short-description origin/develop
+```
+
+**Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/),
+enforced by commitlint** on the `commit-msg` hook. A non-conforming message is rejected
+outright, so it is worth getting right the first time. The types in use here:
+
+| Type       | For                                                    |
+| ---------- | ------------------------------------------------------ |
+| `feat`     | New user-visible behaviour                             |
+| `fix`      | A bug fix                                              |
+| `refactor` | Restructuring with no behaviour change                 |
+| `test`     | Tests only                                             |
+| `docs`     | Documentation, including everything under `openspec/`  |
+| `chore`    | Tooling, dependencies, config                          |
+
+Scope them to the area touched: `fix(absence): …`, `docs(openspec): …`,
+`feat(worklog): …`.
+
+### Git hooks
+
+Husky installs two, via `prepare`:
+
+- **`pre-commit`** runs `lint-staged`, which formats staged `*.{js,jsx,ts,tsx}` files
+  with Prettier. It does not run ESLint — `.lintstagedrc.js` declares the same glob key
+  twice and the Prettier entry overwrites the ESLint one. Run `npm run lint` yourself
+  before pushing; the hook will not catch a lint error for you.
+- **`commit-msg`** runs commitlint.
+
+Markdown is not touched by either hook, and `openspec/` is in `.prettierignore`, so
+spec and documentation files are never reformatted underneath you.
+
+## The OpenSpec workflow
+
+Behaviour is specified before it is built. `openspec/specs/<capability>/spec.md` holds
+the canonical requirements and scenarios for each capability; a change proposal is a
+folder under `openspec/changes/` containing `proposal.md`, `design.md` and `tasks.md`,
+which is archived once the work lands.
+
+The pipeline is **explore → propose → apply → archive**, one pull request per change.
+The `/opsx:*` Claude Code commands generate the artifacts; git is driven separately.
+
+| Stage       | What happens                                                                                                                                    |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **explore** | Thinking and investigation. Nothing is written, nothing is committed.                                                                             |
+| **propose** | Branch off fresh `develop`, generate the artifacts, commit as `docs(openspec): propose <change-name>`, push, and open the pull request.            |
+| **apply**   | Implement it, one commit per top-level task group in `tasks.md`. Finish with the spec sync (below) in its own commit.                              |
+| **archive** | Once CI is green and review is addressed — while the pull request is still open — `mv` the change folder to `changes/archive/YYYY-MM-DD-<name>`.   |
+
+### Syncing specs at the end of apply, not at archive
+
+The last commit of the apply stage applies the change's spec deltas to
+`openspec/specs/`, together with a regenerated `openspec/COVERAGE.md`:
+
+```
+docs(openspec): sync <capability> spec(s) for <change-name>
+```
+
+This cannot wait for archiving. `scripts/spec-coverage.mjs` reads only
+`openspec/specs/`, so a change that adds scenarios leaves every annotation citing them
+unresolvable — and CI's `spec:coverage:ci` step red — until the delta reaches the
+canonical specs. Archiving is meant to happen on green CI, so the sync has to come
+first.
+
+Two things the sync does not do for you:
+
+- **Open Questions the change resolves must be removed by hand.** The delta format has
+  no operation for them, and a resolved question left in the canonical spec is a false
+  statement. Check every capability the change touches, not only the ones with a delta.
+- **The archive commit stays on its own.** Keep the `mv` isolated from implementation
+  commits so it renders as a rename and reverts as a unit.
+
+## Adding behaviour: the checklist
+
+A new requirement is not finished when the code works.
+
+1. **Spec it** — requirement and scenarios in the change's delta, then synced into
+   `openspec/specs/`.
+2. **Test it** — Jest for the rules, Playwright for the journey. Every scenario needs a
+   test or an exemption, and every requirement needs a Playwright test or a categorised
+   one. [Testing](testing.md#spec-to-test-traceability) has the rules and the four
+   exemption categories.
+3. **Annotate it** — `// @scenario <capability>/<scenario name>` above the test, and
+   only if the test asserts that scenario's THEN. Nothing can catch an over-claim
+   automatically; it is a review check.
+4. **Regenerate** — `npm run spec:coverage`, and commit `openspec/COVERAGE.md`.
+5. **Document it** — see below.
+
+## Keeping the documentation true
+
+Two sets of docs go stale in different ways.
+
+**Developer docs** — this folder, plus `CLAUDE.md`, [`e2e/README.md`](../e2e/README.md)
+and the root `README.md`. Hand-written, so nothing detects the drift. If your change
+alters a command, an environment variable, a layer boundary, the data model, or how
+tests are run, update the page that describes it in the same pull request.
+
+**The user guide** — `docs/user-guide/`, generated from the OpenSpec specs by the
+`/generate-user-guides` skill and published to
+[GitHub Pages](https://oskkos.github.io/saldo/) on push to `develop`. Do not hand-edit
+the generated pages; the traceability footers record which requirement hash each page
+was built from, and `--check` reports staleness against it.
+
+```
+/generate-user-guides            # regenerate only what changed
+/generate-user-guides worklog    # scope to a capability, page, or requirement
+/generate-user-guides --check    # staleness report, writes nothing
+```
+
+[`docs/user-guide/README.md`](user-guide/README.md) covers the layout, the mkdocs
+toolchain, and how to serve the site locally.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# Saldo documentation
+
+## For developers
+
+| Document                                     | Read it when                                                                                       |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [Getting started](getting-started.md)        | Setting up locally — prerequisites, the Docker and non-Docker paths, environment variables, troubleshooting. |
+| [Architecture](architecture.md)              | Before your first change. Layer boundaries, the directory map, the data model, and the conventions that cause wrong code if unknown. |
+| [Testing](testing.md)                        | Writing or running tests. The two layers, coverage, and spec-to-test traceability.                     |
+| [Contributing](CONTRIBUTING.md)              | Opening a pull request. Commit conventions, git hooks, and the OpenSpec workflow.                      |
+| [`e2e/README.md`](../e2e/README.md)          | Working inside the Playwright suite — fixtures, seeding, and writing a date-agnostic test.             |
+| [`CLAUDE.md`](../CLAUDE.md)                  | Working with Claude Code on this repository.                                                            |
+
+## For users
+
+The [user guide](https://oskkos.github.io/saldo/) is a task-oriented guide to using
+Saldo, generated from the OpenSpec specs and published to GitHub Pages.
+[`user-guide/README.md`](user-guide/README.md) explains how it is authored, built and
+regenerated.
+
+## Specifications
+
+[`openspec/specs/`](../openspec/specs/) holds the canonical requirements and scenarios
+for each capability — the behaviour the code is meant to have, and the source both the
+test-coverage map and the user guide are generated from.
+[`openspec/COVERAGE.md`](../openspec/COVERAGE.md) is that generated map.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,163 @@
+# Architecture
+
+Saldo is a server-first Next.js App Router application. Almost every page is an async
+server component that reads its own data; the client bundle exists for the parts that
+genuinely need interactivity — forms, the clock, the charts.
+
+## The domain in one paragraph
+
+The **saldo** is a running balance between the hours a user actually worked and the
+hours expected of them. It is computed forward from the user's `begin_date`, seeded
+with an initial balance, and expected minutes accrue only on working days — weekends
+and public holidays (via `date-holidays`) are skipped. The default expectation is
+`EXPECTED_HOURS_PER_DAY = 7.5` (`src/constants/index.ts`), overridable per user in
+settings and per date through `ExpectedHoursOverride`. The whole calculation lives in
+`src/services/index.tsx` and touches neither the database nor the session.
+
+## Layers
+
+```
+page / component  →  action  →  repository  →  Prisma  →  PostgreSQL
+                        │
+                     services  (pure; no DB, no session)
+```
+
+The direction matters more than the names. Nothing skips a layer inward, and nothing
+reaches back outward.
+
+### `src/app/` — pages and routes
+
+App Router pages, async server components by default. Route groups: `(calendar)` for
+the home view, `(login)` for signin/signup/forgot/reset. The NextAuth route handler
+lives under `api/`.
+
+Pages read data by calling repository functions directly. There is no API layer
+between a page and its data, because a server component already runs on the server —
+adding one would only add a network hop and a second place for authorization to be
+forgotten.
+
+### `src/actions/` — the mutation boundary
+
+One `'use server'` module. Every mutation in the app goes through it: worklog CRUD,
+settings, the clock, signup, password reset.
+
+An action validates its input against a Zod schema from `src/schemas/`, then delegates
+to a repository. This is the only place a client component is allowed to trigger a
+write.
+
+**Return errors the user should read; do not throw them.** A production build replaces
+the message of anything thrown out of a server action with an opaque digest, so a
+thrown error that reads perfectly in `next dev` says nothing at all in production.
+`onAbsenceSubmit` returning its conflict is the worked example. This is not a style
+preference — it is the difference between a useful toast and an empty one, and it is
+invisible until you test against a real build.
+
+### `src/repository/` — data access and the authorization gate
+
+`server-only` modules, one per aggregate: worklog, settings, clock, user,
+expected-hours override.
+
+Every function starts by calling `getUserFromSession()` and throws if there is no
+user. Functions that touch an existing row additionally compare `user_id` against the
+session user and throw `'User mismatch.'` on a mismatch — an id in a URL is not
+evidence of ownership. Because the gate lives here rather than in the pages, a new
+page cannot forget it.
+
+Database calls are wrapped in `Sentry.startSpan`.
+
+This layer is also the translation boundary. Prisma's rows are `snake_case` and shaped
+by the schema; the rest of the app speaks the `camelCase` domain types in
+`src/types/`. Mapper functions (`toWorklog` and friends) convert on the way out.
+**Prisma types do not leak past this layer** — that is what keeps the schema free to
+change without a rewrite above it.
+
+### `src/services/` — pure business logic
+
+The saldo calculation, worklog summing and sorting, minutes↔badge formatting. No
+database, no session, no I/O. This is the layer that is cheap to test exhaustively,
+which is why the interesting rules live here rather than inside a component.
+
+`forgotPasswordMailSender.ts` is the exception that proves it — it talks to Mailjet,
+and it sits alone.
+
+### `src/auth/` — NextAuth configuration
+
+JWT session strategy, with Credentials, Google and GitHub providers. On first sign-in
+`onAfterSignin` upserts the user and seeds default `Settings`. The user's numeric
+database id is stashed on the token as `token.userId` and surfaced as
+`session.user.id`; `getUserFromSession()` is the gate every repository call goes
+through.
+
+## Directory map
+
+| Path              | Files | What lives there                                                     |
+| ----------------- | ----- | -------------------------------------------------------------------- |
+| `src/app/`        | ~59   | Pages, route groups, layouts, the NextAuth handler                    |
+| `src/components/` | ~64   | Client components — forms, clock, mini calendar, worklog items        |
+| `src/repository/` | ~12   | `server-only` data access; ownership enforced here                    |
+| `src/util/`       | ~12   | Date helpers, branded date types, assertion guards, duration maths    |
+| `src/schemas/`    | ~11   | Zod schemas, one per form                                             |
+| `src/auth/`       | ~6    | NextAuth options and session helpers                                  |
+| `src/actions/`    | ~5    | The single `'use server'` module and its tests                        |
+| `src/services/`   | ~3    | Pure domain logic — the saldo calculation                             |
+| `src/types/`      | ~2    | Domain types (`Worklog`, `Settings`, `User`, `AbsenceReason`, …)      |
+| `src/constants/`  | 1     | `EXPECTED_HOURS_PER_DAY`, worklog defaults, theme names               |
+| `src/generated/`  | —     | Generated Prisma client. Not hand-edited, not in `node_modules`       |
+
+Tests sit in `__tests__/` directories beside the code they cover.
+
+## Conventions that bite
+
+These are the ones that cause wrong code rather than untidy code.
+
+### All date maths is UTC
+
+`src/util/date.ts` calls `dayjs.tz.setDefault('UTC')` and exports the helpers the app
+should use — `add`, `subtract`, `startOfDay`, `endOfDay`, `sameDay`, `diffInMinutes`,
+`isWeekend`, `isHoliday`, `isNonWorkingDay`, `now`. Reaching for `dayjs` directly
+reintroduces the local timezone and produces a saldo that is correct on your machine
+and wrong on the server. The Playwright suite deliberately runs the app server in a
+non-UTC timezone to catch exactly this.
+
+### Branded date types
+
+`src/util/dateFormatter.ts` defines opaque string types — `Date_ISODay`, `Date_Time`,
+`Date_YearAndMonth` — and `src/util/assertionFunctions.ts` provides the guards that
+construct them (`assertIsISODay`, `assertIsTime`, `assertIsYearAndMonth`,
+`assertIsAbsenceReason`, `assertExists`).
+
+They are all `string` at runtime; the brand exists purely so the compiler can tell
+`'2026-07-27'` from `'08:00'`. Prefer them over raw strings when passing formatted
+dates around, and construct them through the guards rather than casting — a cast
+asserts a format nobody checked.
+
+### The Prisma client is generated to `src/generated/prisma`
+
+Import from `@/generated/prisma/client`, never from `@prisma/client`. Run
+`prisma generate` after any schema change; `postinstall` covers a fresh clone.
+
+### The path alias is `@/*` → `src/*`
+
+Configured in both `tsconfig.json` and the Jest config, so it resolves the same in
+tests.
+
+## Data model
+
+Six Prisma models in `prisma/schema.prisma`:
+
+- **`User`** — email, optional name and password (null for OAuth-only accounts).
+- **`Settings`** — one per user: `begin_date`, initial balance, default from/to times,
+  `expected_minutes_per_day` (default 450 = 7.5 h).
+- **`Worklog`** — a `from`/`to` pair on a user, with an optional comment, a
+  `subtract_lunch_break` flag, and an optional `absence`. An absence is a worklog with
+  its `absence` column set, not a separate table.
+- **`Absence`** (enum) — `holiday`, `flex_hours`, `sick_leave`, `other`.
+- **`ExpectedHoursOverride`** — per-date expected minutes with an optional label.
+- **`PasswordResetData`** — reset token and expiry, one per user.
+
+## Where to read next
+
+- [Testing](testing.md) — the two layers, and how a spec scenario becomes a test.
+- [`e2e/README.md`](../e2e/README.md) — the Playwright harness in detail.
+- [`openspec/specs/`](../openspec/specs/) — the behaviour these layers implement,
+  written as requirements and scenarios.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,38 +1,147 @@
-# Getting Started
+# Getting started
 
-Prerequisites
+Getting Saldo running locally, from a fresh clone to a signed-in session.
 
-- Node.js 18+ and npm
-- Docker and Docker Compose
+## Prerequisites
 
-Install dependencies
+- **Node.js 20+** and npm. CI builds on 20.x, and Next.js 16 will not run on 18.
+- **Docker and Docker Compose**, unless you are bringing your own PostgreSQL.
 
-- npm install
+## The short version
 
-Run locally (without Docker)
+```bash
+npm install               # also runs `prisma generate` via postinstall
+docker compose up -d db   # Postgres 16 on localhost:3006
+./run-migrations.sh       # prisma migrate deploy
+npm run dev               # http://localhost:3000
+```
 
-- Ensure a PostgreSQL database is available and set POSTGRES_PRISMA_URL in .env
-- Apply migrations: POSTGRES_PRISMA_URL="postgres://postgres:password@localhost:3006/saldo" npx prisma migrate deploy
-- Start dev server: npm run dev
+Open http://localhost:3000, choose **Sign up**, and create an account with an email
+and password. There is no seeded user in the dev database — the e2e suite seeds its
+own, in a different database.
 
-Run with Docker Compose
+## Setup in full
 
-- Start database: docker compose up -d db (Postgres exposed at localhost:3006)
-- Apply migrations in the compose environment: ./run-migrations.sh
-  - The script brings up db and runs: POSTGRES_PRISMA_URL="postgres://postgres:password@localhost:3006/saldo" npx prisma migrate deploy
-- Start app: docker compose up (app on http://localhost:3000)
-  - The dev container also runs npm install and starts Next.js
+### 1. Install dependencies
 
-Environment variables
+```bash
+npm install
+```
 
-- POSTGRES_PRISMA_URL: Database connection string used by Prisma and runtime
-- POSTGRES_URL_NON_POOLING: Optional; not required for prisma migrate deploy
-- NEXTAUTH_URL, NEXTAUTH_SECRET: Required for auth in non-local environments
-- Provider OAuth credentials as needed (e.g., GITHUB*\*, GOOGLE*\*)
-- Optional: SENTRY_DSN
+The `postinstall` script runs `prisma generate`. That matters more here than in most
+projects: the Prisma client is generated to `src/generated/prisma`, **not** into
+`node_modules`, so a clone that skips install has no client at all and typechecking
+fails on imports rather than at runtime.
 
-Common commands
+### 2. Start PostgreSQL
 
-- Build: npm run build
-- Test (CI): npm run test:ci
-- Lint/format (CI): npm run lint:ci && npm run prettier:ci
+```bash
+docker compose up -d db
+```
+
+`docker-compose.yml` runs `postgres:16` with database `saldo`, user `postgres`,
+password `password`, published on **host port 3006** (container 5432). Nothing in the
+compose setup is intended to leave your machine.
+
+Bringing your own PostgreSQL instead is fine — create a database and point
+`POSTGRES_PRISMA_URL` at it. The rest of this page assumes the compose one.
+
+### 3. Apply migrations
+
+```bash
+./run-migrations.sh
+```
+
+The script brings up `db` if it is not already running, then runs `prisma migrate
+deploy` against `postgres://postgres:password@localhost:3006/saldo`. It hardcodes that
+URL, so it is only useful for the compose database; against your own, run migrations
+directly:
+
+```bash
+POSTGRES_PRISMA_URL="postgres://user:pass@host:5432/db" npx prisma migrate deploy
+```
+
+### 4. Run the app
+
+Two ways, and the difference is where the app process lives:
+
+```bash
+npm run dev          # app on your host, database in Docker  ← the usual loop
+```
+
+```bash
+docker compose up    # app in Docker too, on http://localhost:3000
+```
+
+The container path is the one that needs no local Node at all: `dev.Dockerfile`
+installs dependencies and starts Next.js inside the container, reaching the database
+at `db:5432` rather than `localhost:3006`. It mounts the repository as a volume, so
+edits still hot-reload. Day to day, `npm run dev` is faster.
+
+## Environment variables
+
+Everything is read from `.env` in development. The compose file passes the two
+database URLs to the app container directly, so a plain compose run needs no `.env`
+at all — but `npm run dev` does.
+
+| Variable                             | Required                        | What it does                                                                                         |
+| ------------------------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `POSTGRES_PRISMA_URL`                | **always**                      | The connection string Prisma and the runtime both use.                                                 |
+| `POSTGRES_URL_NON_POOLING`           | for `prisma migrate dev`        | Shadow database URL (`prisma.config.mjs`). `migrate deploy` does not need it.                          |
+| `NEXTAUTH_SECRET`                    | outside local dev               | Signs the JWT session. Generate one with `openssl rand -base64 32`.                                    |
+| `NEXTAUTH_URL`                       | outside local dev               | The app's canonical URL. NextAuth infers it on localhost.                                              |
+| `GOOGLE_CLIENT_ID` / `_SECRET`       | to use Google sign-in           | OAuth credentials.                                                                                     |
+| `GITHUB_CLIENT_ID` / `_SECRET`       | to use GitHub sign-in           | OAuth credentials.                                                                                     |
+| `MAILJET_API_KEY` / `_SECRET_KEY`    | to send password-reset mail     | Without them the reset request fails when it tries to send.                                            |
+| `MAILJET_RESET_PASSWORD_TEMPLATE_ID` | to send password-reset mail     | Mailjet template used for the reset email.                                                             |
+| `E2E_COVERAGE`                       | never, by hand                  | Set by `npm run test:e2e:coverage`. See [Testing](testing.md#coverage).                                |
+
+Two things that are easy to get wrong:
+
+- **The OAuth providers are always registered**, whether or not their variables are
+  set. `authSession.ts` wraps each in `String(...)`, so an unset variable becomes the
+  literal `"undefined"` and the button fails at the provider rather than disappearing.
+  Sign-up with email and password works regardless — that is the path to use locally.
+- **Sentry's DSN is hardcoded** in `src/instrumentation.ts` and
+  `sentry.client.config.ts`. There is no `SENTRY_DSN` variable to set.
+
+## Common commands
+
+| Command                    | What it does                                       |
+| -------------------------- | -------------------------------------------------- |
+| `npm run dev`              | Dev server on port 3000                            |
+| `npm run build`            | Production build, into `build/` (into `.next` on Vercel) |
+| `npm start`                | Serve a production build                           |
+| `npm run test:ci`          | Jest once, with coverage                           |
+| `npm test`                 | Jest in **watch mode** — does not exit             |
+| `npm run test:e2e`         | Playwright suite (needs one-time setup)            |
+| `npm run lint`             | ESLint (`--max-warnings=0`) and Prettier, check only |
+| `npm run lint:fix`         | ESLint `--fix` and Prettier `--write`              |
+| `npm run spec:coverage`    | Regenerate `openspec/COVERAGE.md`                  |
+| `npx prisma migrate dev`   | Create and apply a migration after a schema edit   |
+| `npx prisma generate`      | Regenerate the client into `src/generated/prisma`  |
+
+[Testing](testing.md) covers the two test layers in full, including the one-time
+setup the Playwright suite needs.
+
+## Troubleshooting
+
+**`port is already allocated` on 3006.** Something else is on that port — often a
+previous `docker compose` stack. `docker compose down` first, or change the host side
+of the mapping in `docker-compose.yml` and update `POSTGRES_PRISMA_URL` to match.
+
+**Imports from `@/generated/prisma/client` do not resolve.** The client has not been
+generated. Run `npx prisma generate`. Do this after every schema change, too — a
+stale client typechecks against the old columns.
+
+**`prisma migrate dev` complains about a shadow database.** Set
+`POSTGRES_URL_NON_POOLING` as well; `migrate dev` needs somewhere to replay migrations
+and `prisma.config.mjs` reads that variable for it.
+
+**Migrations appear to do nothing.** Check which database you are pointed at.
+`run-migrations.sh` always targets the compose `saldo` database, and the e2e suite
+uses a separate `saldo_test` — running the wrong one is the usual cause of a schema
+that looks unchanged.
+
+**Sign-in fails with no visible error.** If you are trying Google or GitHub without
+credentials configured, that is expected — see the note above. Use email and password.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,166 @@
+# Testing
+
+Two layers, deliberately covering different halves of the codebase.
+
+| Layer          | Runner                    | Lives in            | Covers                                                    |
+| -------------- | ------------------------- | ------------------- | ---------------------------------------------------------- |
+| Unit / server  | Jest (jsdom)              | `src/**/__tests__/` | `services`, `repository`, `util`, `schemas`, `actions`      |
+| End-to-end     | Playwright                | `e2e/`              | Every `page.tsx` and component, driven in a real browser    |
+
+`npm run test:ci` runs Jest only — `e2e/` is excluded from it. The two report to
+Codecov under separate flags for the same reason they exist separately: neither one
+describes the codebase alone.
+
+## Running them
+
+```bash
+npm run test:ci                                  # Jest, once, with coverage
+npm test                                         # Jest in WATCH mode — does not exit
+npx jest src/services/__tests__/someFile.test.ts # a single file
+npx jest src/services -t "computes the balance"  # filter by test name
+```
+
+The Playwright suite needs a one-time setup, then runs on its own:
+
+```bash
+docker compose up -d db
+docker compose exec -T db psql -U postgres -c "CREATE DATABASE saldo_test"  # once
+cp .env.e2e.example .env.e2e                                                # once
+npm run test:e2e                                 # migrations + seed + tests
+npm run test:e2e:ui                              # watch and debug
+```
+
+It boots the app on **port 3100** against `saldo_test`, so it never collides with a
+dev server on 3000 and never touches your dev data. [`e2e/README.md`](../e2e/README.md)
+documents the harness — the fixtures, the shared locators, the seeding helpers, and
+the rules for writing a test that survives being run on an arbitrary date.
+
+## What belongs where
+
+Put a rule where it can be pinned most precisely. The saldo calculation has dozens of
+edge cases around holidays, partial days and absence reasons; those belong in Jest,
+where each is three lines. Whether the badge actually updates after you save a worklog
+is a question about wiring, and only a browser can answer it.
+
+In practice:
+
+- **Jest** — anything in `services` (pure, so exhaustive cases are cheap), repository
+  behaviour with Prisma and the session mocked, Zod schema validation, date helpers.
+- **Playwright** — the user-visible journey for each capability, and anything whose
+  failure mode is "the pieces don't talk to each other".
+
+One asymmetry worth knowing: **a test asserting a message the server produced must be
+run against a production build.** Locally the harness starts `next dev`; CI starts
+`npm run start`. A production build replaces the message of anything *thrown* out of a
+server action with an opaque digest, so a toast that reads fine in dev can be empty in
+CI. Check it the way CI will:
+
+```bash
+npm run build && CI=1 npm run test:e2e
+```
+
+## Coverage
+
+Both layers report line coverage to Codecov, Jest under the `unit` flag and Playwright
+under `e2e`. They cover near-complementary halves, so only the pair describes the
+whole; both are set to `carryforward` in `codecov.yml` so a layer that did not run is
+never read as a layer that covers nothing.
+
+E2E coverage is off by default:
+
+```bash
+npm run test:e2e:coverage    # E2E_COVERAGE=1
+npm run coverage:e2e:report  # → coverage-e2e/{server,browser}/lcov.info
+```
+
+One switch drives all three moving parts — source maps in the build, `NODE_V8_COVERAGE`
+on the app server, and the `page.coverage` collector in `e2e/fixtures.ts`. A plain
+`npm run test:e2e` is unaffected and writes nothing.
+
+Two properties of this setup are deliberate and worth not undoing:
+
+- **One report per runtime, both uploaded under `e2e`.** They are not merged locally.
+  The converter resolves both runtimes to the same source path but does not union
+  their execution counts, so merging would let the server's zero mask a browser hit
+  for every file both touch. Codecov unions uploads within a flag, which is where the
+  merge correctly happens.
+- **The report step fails loudly** when a runtime contributed nothing, when no project
+  source survives filtering, or when a path does not resolve on disk. Silent-empty is
+  this mechanism's characteristic failure: Codecov would carry the previous report
+  forward and the number would stay plausible while ceasing to be true.
+
+**Every spec takes `test` from `e2e/fixtures.ts`**, not from `@playwright/test` — that
+import is what starts the browser profiler. A file that imports the runner directly is
+silently left out of coverage and nothing about it looks wrong, so
+`scripts/__tests__/e2e-coverage.test.ts` scans the directory and fails the build on
+one. Importing `expect` or `type Page` from the runner is fine.
+
+**Execution is not assertion.** A file is green here because it ran, not because
+anything checked what it did — `navbar.tsx` renders on every page. What a test
+actually proves is recorded by the annotations below.
+
+## Spec-to-test traceability
+
+CI enforces two rules from the same annotations:
+
+1. Every **scenario** in `openspec/specs/` is covered by a test, or explicitly exempt.
+2. Every **requirement** has at least one scenario covered by a **Playwright** test, or
+   carries a categorised end-to-end exemption.
+
+```bash
+npm run spec:coverage      # regenerate openspec/COVERAGE.md (commit the result)
+npm run spec:coverage:ci   # what CI runs: --check --strict, writes nothing
+```
+
+### Declaring coverage
+
+Put the claim directly above the test, in either layer:
+
+```ts
+// @scenario time-clock/Clock in when idle
+it('records the session start', () => { ... })
+```
+
+Stack the comments to claim several scenarios. On a `describe` or `test.describe` the
+claim applies to every test inside. Many-to-many is fine — one test may cover several
+scenarios, and several tests may jointly cover one. The layer is read from the test's
+path (`e2e/**`); there is no extra syntax for it.
+
+**A test may claim a scenario only if it asserts that scenario's THEN.** No tool can
+catch an over-claim — this is a review check, and it is the one that decides whether
+the coverage map means anything. If a scenario's THEN spans layers ("throws a
+validation error **and** nothing is written"), a schema test alone does not cover it:
+assert the persistence half at the action level too, or let two tests jointly cover it.
+
+Regenerate and commit `openspec/COVERAGE.md` whenever annotations or specs change; CI
+fails on a stale map. Renaming a scenario deliberately breaks every annotation citing
+it — that is the signal to re-read those tests, not an inconvenience to route around.
+
+### Exemptions
+
+Something genuinely untestable gets an entry under `scenarios` in
+`scripts/spec-coverage.exemptions.json`, with a reason in your own words (a
+`<capability>/*` wildcard is allowed).
+
+A requirement with no Playwright test needs an entry under `requirementsWithoutE2e`
+carrying one of four categories:
+
+| Category              | Means                                                             |
+| --------------------- | ----------------------------------------------------------------- |
+| `no-ui`               | The requirement has no user-visible surface at all.               |
+| `unit-appropriate`    | Observable, but pinned more precisely at a lower layer.           |
+| `external-dependency` | Needs a third party the test environment cannot drive.            |
+| `harness-cost`        | Declined deliberately: the setup outweighs the confidence gained. |
+
+`harness-cost` also requires `coveredAt`, naming a test file that does cover the
+requirement, and that file must exist. It is the only category asserting a judgement
+rather than a fact, so the claim is made checkable rather than left unfalsifiable.
+
+Exemptions cannot rot quietly: one naming an unknown scenario or requirement fails the
+run, and so does one for something a test has since started covering — coverage
+arriving later forces the exemption out rather than letting it hide.
+
+**One known gap.** The tool counts annotations, not results. A `test.fixme` or
+`test.skip` carrying `@scenario` lines reports coverage that never runs. Delete a test
+you cannot make pass, or exempt its requirement honestly — do not leave it skipped with
+its annotations attached.


### PR DESCRIPTION
## Why

The only architecture write-up lived in `CLAUDE.md` — an agent instruction file, not somewhere to send a contributor — and `docs/getting-started.md` was 38 lines of terse bullets that listed an environment variable the app does not read.

## What changed

| File | |
| --- | --- |
| `docs/README.md` | **New** — index, so browsing to `docs/` lands somewhere |
| `docs/getting-started.md` | **Rewritten** (38 → 161 lines): Docker and non-Docker paths as complete walkthroughs, a real env-var table, troubleshooting |
| `docs/architecture.md` | **New** — layer boundaries, `src/` map, data model, the conventions that cause wrong code |
| `docs/testing.md` | **New** — the two layers and what belongs in each, coverage, spec-to-test traceability |
| `docs/CONTRIBUTING.md` | **New** — commit conventions, git hooks, the OpenSpec pipeline |
| `README.md` | Development / Architecture / Testing sections replaced by a docs table |
| `CLAUDE.md` | Split by kind rather than topic (see below) |

### The CLAUDE.md split

`CLAUDE.md` is loaded into every Claude session, which is exactly why it held this material. Turning it into a link farm would be a regression — Claude would have to open four files to learn the UTC-dates rule, and often wouldn't.

So: **rules stay** (the things that produce wrong code — UTC-only dates, branded types, Prisma client path, ownership enforcement, return-don't-throw), **explanations move** to `docs/`, and the `/opsx:*` git-driving instructions stay verbatim since they're directions to an agent.

### New standing instruction

A `## After every change: check the docs` section with a trigger → file table, plus a requirement to say which docs were checked when none needed changing — silence otherwise reads as "not considered".

## Findings, documented as-is rather than fixed

1. **`.lintstagedrc.js` declares `'*.{js,jsx,ts,tsx}'` twice.** The Prettier entry overwrites the ESLint one, so **pre-commit never runs ESLint**. Both `CLAUDE.md` and `CONTRIBUTING.md` now say so and tell you to run `npm run lint` yourself. Worth a one-line fix separately.
2. **`SENTRY_DSN` is not read anywhere** — the DSN is hardcoded in `src/instrumentation.ts` and `sentry.client.config.ts`. Removed from the env table.
3. **`openspec/config.yaml` holds a third copy of the architecture summary.** Left alone (different consumer), but it is now the one place that can drift silently.

## Verification

- `npm run lint` — pass
- `npm run spec:coverage:ci` — pass
- `npm run test:ci` — 80 suites, 611 tests, pass
- Every relative link and both cross-file anchors resolve (checked by script)

Docs-only; no source files touched.